### PR TITLE
Fix arrow navigation stealing focus back when inline editor form is dirty

### DIFF
--- a/e2e/dash-inline-editor.test.ts
+++ b/e2e/dash-inline-editor.test.ts
@@ -291,6 +291,33 @@ test.describe('/ja/dash inline editor labels, arrows, and sustained focus', () =
 		}, [title_a, title_b])
 	})
 
+	test('ArrowDown after editing title (dirty form) keeps focus on the next row', async ({
+		page,
+	}) => {
+		const run_id = `E2E_AND_${String(Date.now())}`
+		const title_a = `${run_id}_A`
+		const title_b = `${run_id}_B`
+		const title_b_edited = `${title_b}_edit`
+
+		await playwright_dash_ux.run_authed(page, async () => {
+			await playwright_dash_ux.seed_tasks(page, [title_a, title_b])
+			await page.getByTestId(tid.search).fill(run_id)
+			await expect(page.getByTestId(tid.task_row).filter({ hasText: run_id })).toHaveCount(2, {
+				timeout: RELOAD_STABLE_TIMEOUT_MS,
+			})
+
+			await page.getByRole('button', { name: title_b }).click()
+			const inline_title = page.getByTestId(tid.inline_title)
+
+			await expect(inline_title).toHaveValue(title_b)
+			await inline_title.fill(title_b_edited)
+			await expect(inline_title).toHaveValue(title_b_edited)
+			await page.keyboard.press('ArrowDown')
+			// After dirty-form arrow navigation, focus must stay on the next task (title_a), not stolen back.
+			await expect_focused_inline_value(page, title_a)
+		}, [title_b_edited, title_a])
+	})
+
 	test('ArrowUp on the title moves edit focus to the previous row', async ({ page }) => {
 		const run_id = `E2E_AUP_${String(Date.now())}`
 		const title_a = `${run_id}_A`

--- a/e2e/dash-inline-editor.test.ts
+++ b/e2e/dash-inline-editor.test.ts
@@ -312,7 +312,11 @@ test.describe('/ja/dash inline editor labels, arrows, and sustained focus', () =
 			await expect(inline_title).toHaveValue(title_b)
 			await inline_title.fill(title_b_edited)
 			await expect(inline_title).toHaveValue(title_b_edited)
+			const save_response = wait_for_update_task_ok(page)
+
 			await page.keyboard.press('ArrowDown')
+			// Wait for the dirty-form save to complete before asserting focus so the race is fully resolved.
+			await save_response
 			// After dirty-form arrow navigation, focus must stay on the next task (title_a), not stolen back.
 			await expect_focused_inline_value(page, title_a)
 		}, [title_b_edited, title_a])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tasks",
 	"private": true,
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/lib/components/dash/DashTaskInlineEditor.svelte
+++ b/src/lib/components/dash/DashTaskInlineEditor.svelte
@@ -99,6 +99,8 @@
 	let is_rr_post_close_submit = false
 	/** Prevents the focusout path from triggering a second discard when arrow navigation already handled it. */
 	let is_arrow_nav_discard_active = false
+	/** Set when arrow navigation is initiated so finalize_success_then_refocus skips stealing focus back. */
+	let is_navigating_away = false
 
 	function clear_blur_discard_timer(): void {
 		if (blur_discard_timer === undefined) return
@@ -714,6 +716,7 @@
 	function handle_arrow_without_title(direction: 'up' | 'down'): void {
 		if (!is_never_titled_row()) revert_to_task_item()
 
+		is_navigating_away = true
 		on_navigate_arrow?.(direction)
 
 		if (is_never_titled_row()) {
@@ -725,6 +728,7 @@
 	function handle_arrow_with_title(direction: 'up' | 'down'): void {
 		if (is_form_dirty()) try_submit_form()
 
+		is_navigating_away = true
 		on_navigate_arrow?.(direction)
 	}
 
@@ -841,7 +845,7 @@
 		await run_after_successful_update(reason, is_saved_via_blur_commit)
 		reset_blur_defer_flags()
 
-		if (!is_blur_commit_exit(reason, is_saved_via_blur_commit)) {
+		if (!is_blur_commit_exit(reason, is_saved_via_blur_commit) && !is_navigating_away) {
 			await tick()
 			await next_animation_frame()
 			await next_animation_frame()

--- a/src/lib/components/dash/DashTaskInlineEditor.svelte
+++ b/src/lib/components/dash/DashTaskInlineEditor.svelte
@@ -845,7 +845,11 @@
 		await run_after_successful_update(reason, is_saved_via_blur_commit)
 		reset_blur_defer_flags()
 
-		if (!is_blur_commit_exit(reason, is_saved_via_blur_commit) && !is_navigating_away) {
+		const did_navigate_away = is_navigating_away
+
+		is_navigating_away = false
+
+		if (!is_blur_commit_exit(reason, is_saved_via_blur_commit) && !did_navigate_away) {
 			await tick()
 			await next_animation_frame()
 			await next_animation_frame()


### PR DESCRIPTION
## Summary
- Added `is_navigating_away` flag in `DashTaskInlineEditor` to prevent `finalize_success_then_refocus` from stealing focus back when arrow navigation triggers a dirty-form save
- Added E2E regression test covering the dirty-form arrow navigation scenario

## Test plan
- [ ] Run `pnpm test` and confirm all E2E and unit tests pass
- [ ] Manually open `/dash`, edit a task title (dirty form), press ArrowDown — focus should move to the next row, not get stolen back

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)