### PR TITLE
Fix Cmd+Shift+O creating task in display state while editing and revert wrong #163 guard

### DIFF
--- a/e2e/dash-inline-editor.test.ts
+++ b/e2e/dash-inline-editor.test.ts
@@ -491,6 +491,7 @@ test.describe('/ja/dash inline editor labels, arrows, and sustained focus', () =
 			await expect(page.getByTestId(tid.inline_title)).toHaveCount(1, {
 				timeout: RELOAD_STABLE_TIMEOUT_MS,
 			})
+			await expect(page.getByTestId(tid.inline_title)).toBeFocused()
 		})
 	})
 

--- a/e2e/dash-inline-editor.test.ts
+++ b/e2e/dash-inline-editor.test.ts
@@ -441,7 +441,9 @@ test.describe('/ja/dash inline editor labels, arrows, and sustained focus', () =
 		})
 	})
 
-	test('Cmd+Shift+O while editing an existing task does not create a new empty task', async ({
+	// Regression #168: #163 incorrectly guarded all editing cases; shortcut while editing an existing
+	// task should open a new empty editor at the top (same as the Add a task button), not refocus.
+	test('Cmd+Shift+O while editing an existing task opens a new task editor at the top', async ({
 		page,
 	}) => {
 		const run_id = `E2E_SHTO_${String(Date.now())}`
@@ -454,22 +456,42 @@ test.describe('/ja/dash inline editor labels, arrows, and sustained focus', () =
 			await expect(page.getByTestId(tid.inline_title)).toHaveCount(1, {
 				timeout: RELOAD_STABLE_TIMEOUT_MS,
 			})
-			await expect(page.getByTestId(tid.inline_title)).toHaveValue(run_id)
+			await expect(page.getByTestId(tid.inline_title)).toHaveValue('')
+			await expect_dom_focus_on(page.getByTestId(tid.inline_title))
 		}, [run_id])
 	})
 
-	test('Cmd+Shift+O while editing an existing task refocuses the inline title', async ({
+	test('Add a task button while editing an existing task opens a new task editor at the top', async ({
 		page,
 	}) => {
-		const run_id = `E2E_SHTF_${String(Date.now())}`
+		const run_id = `E2E_BTN_${String(Date.now())}`
 
 		await playwright_dash_ux.run_authed(page, async () => {
 			await playwright_dash_ux.save_new_task(page, run_id)
 			await page.getByRole('button', { name: run_id }).click()
 			await expect(page.getByTestId(tid.inline_title)).toHaveValue(run_id)
-			await page.keyboard.press(SHORTCUT_ADD_TASK)
+			await page.getByTestId(tid.add_task).click()
+			await expect(page.getByTestId(tid.inline_title)).toHaveCount(1, {
+				timeout: RELOAD_STABLE_TIMEOUT_MS,
+			})
+			await expect(page.getByTestId(tid.inline_title)).toHaveValue('')
 			await expect_dom_focus_on(page.getByTestId(tid.inline_title))
 		}, [run_id])
+	})
+
+	test('Cmd+Shift+O while editing the new empty task refocuses it without creating a duplicate', async ({
+		page,
+	}) => {
+		await playwright_dash_ux.run_authed(page, async () => {
+			await page.keyboard.press(SHORTCUT_ADD_TASK)
+			await expect(page.getByTestId(tid.inline_title)).toBeVisible({
+				timeout: RELOAD_STABLE_TIMEOUT_MS,
+			})
+			await page.keyboard.press(SHORTCUT_ADD_TASK)
+			await expect(page.getByTestId(tid.inline_title)).toHaveCount(1, {
+				timeout: RELOAD_STABLE_TIMEOUT_MS,
+			})
+		})
 	})
 
 	// Regression #165: discard_empty_inline_task used to call cancel_task_edit() synchronously,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tasks",
 	"private": true,
-	"version": "0.53.0",
+	"version": "0.54.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/lib/components/dash/DashTaskCard.svelte
+++ b/src/lib/components/dash/DashTaskCard.svelte
@@ -230,7 +230,9 @@
 				{form}
 				{input_class}
 				focus_request_id={focus_pulse}
-				on_escape={on_cancel_task_edit}
+				on_escape={() => {
+					if (editing_task_id === task_item.id) on_cancel_task_edit()
+				}}
 				on_saved={on_task_saved}
 				{on_blur_commit_saved}
 				on_title_enter_saved={async () => {

--- a/src/routes/dash/+page.svelte
+++ b/src/routes/dash/+page.svelte
@@ -143,9 +143,12 @@
 		cancel_task_edit()
 		is_begin_add_at_top_running = true
 
+		const editing_snapshot = editing_task_id
+
 		try {
 			const target_id = await resolve_add_at_top_target_id()
 			if (target_id === undefined) return
+			if (editing_task_id !== editing_snapshot) return
 
 			editing_task_id = target_id
 			inline_edit_focus_pulse += 1

--- a/src/routes/dash/+page.svelte
+++ b/src/routes/dash/+page.svelte
@@ -137,16 +137,21 @@
 		return read_first_open_empty_task_id(tasks_state)
 	}
 
-	async function resolve_add_top_target(
-		editor_snapshot: string | undefined,
-	): Promise<string | undefined> {
-		if (editor_snapshot !== undefined) {
+	async function run_add_top_task(): Promise<void> {
+		// Close current editor before network request so its deferred blur
+		// cannot race against the new task's editing state.
+		cancel_task_edit()
+		is_begin_add_at_top_running = true
+
+		try {
+			const target_id = await resolve_add_at_top_target_id()
+			if (target_id === undefined) return
+
+			editing_task_id = target_id
 			inline_edit_focus_pulse += 1
-
-			return undefined
+		} finally {
+			is_begin_add_at_top_running = false
 		}
-
-		return await resolve_add_at_top_target_id()
 	}
 
 	async function begin_add_at_top(): Promise<void> {
@@ -156,19 +161,15 @@
 			return
 		}
 
-		is_begin_add_at_top_running = true
+		const first_open_empty_id = read_first_open_empty_task_id(tasks_state)
 
-		try {
-			const target_id = await resolve_add_top_target(editing_task_id)
-			if (target_id === undefined) return
-
-			/* eslint-disable-next-line require-atomic-updates -- guarded by `is_begin_add_at_top_running` */
-			editing_task_id = target_id
+		if (editing_task_id !== undefined && editing_task_id === first_open_empty_id) {
 			inline_edit_focus_pulse += 1
-		} finally {
-			/* eslint-disable-next-line require-atomic-updates -- release lock after awaited work */
-			is_begin_add_at_top_running = false
+
+			return
 		}
+
+		await run_add_top_task()
 	}
 
 	function is_modifier_key_pressed(key_event: KeyboardEvent): boolean {


### PR DESCRIPTION
## Summary

Fixes #168

- Identified blur race condition causing `Cmd+Shift+O` to create a task in display state (not editing state) while another task was being edited
- Fixed by calling `cancel_task_edit()` before the network request in `begin_add_at_top` so the old editor unmounts cleanly and its deferred blur timer is cancelled
- Narrowed the guard to only skip creation when already editing the first open empty task (the true idempotency case), reverting the overly-broad #163 fix

## Test plan

- [x] `Cmd+Shift+O` while editing an existing task opens a new empty task editor at the top
- [x] "Add a task" button while editing an existing task opens a new empty task editor at the top
- [x] `Cmd+Shift+O` while editing the new empty task refocuses it without creating a duplicate
- [x] All 35 E2E tests pass
- [x] All 116 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)