### PR TITLE
Refactor: extract inline editor state class and split oversized dash components #184

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,6 +50,7 @@
 	"dash_create_title_placeholder": "Task title *",
 	"dash_create_detail_placeholder": "Details (optional)",
 	"dash_create_label_placeholder": "Type a label and press Enter to add...",
+	"dash_label_remove_aria": "Remove label",
 	"dash_create_due_label": "Due date",
 	"dash_create_cancel": "Cancel",
 	"dash_create_saving": "Saving...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -50,6 +50,7 @@
 	"dash_create_title_placeholder": "タスクのタイトル *",
 	"dash_create_detail_placeholder": "詳細（任意）",
 	"dash_create_label_placeholder": "ラベルを入力してEnterで追加...",
+	"dash_label_remove_aria": "ラベルを削除",
 	"dash_create_due_label": "期限",
 	"dash_create_cancel": "キャンセル",
 	"dash_create_saving": "登録中...",

--- a/messages/km.json
+++ b/messages/km.json
@@ -50,6 +50,7 @@
 	"dash_create_title_placeholder": "ចំណងជើងកិច្ចការ *",
 	"dash_create_detail_placeholder": "ព័ត៌មានលម្អិត (ស្រេចចិត្ត)",
 	"dash_create_label_placeholder": "វាយស្លាក ហើយចុច Enter ដើម្បីបន្ថែម...",
+	"dash_label_remove_aria": "Remove label",
 	"dash_create_due_label": "កាលបរិច្ឆេទផុតកំណត់",
 	"dash_create_cancel": "បោះបង់",
 	"dash_create_saving": "កំពុងរក្សាទុក...",

--- a/messages/uz.json
+++ b/messages/uz.json
@@ -50,6 +50,7 @@
 	"dash_create_title_placeholder": "Vazifa sarlavhasi *",
 	"dash_create_detail_placeholder": "Tafsilotlar (ixtiyoriy)",
 	"dash_create_label_placeholder": "Yorliq kiriting va qo'shish uchun Enter bosing...",
+	"dash_label_remove_aria": "Remove label",
 	"dash_create_due_label": "Muddat",
 	"dash_create_cancel": "Bekor qilish",
 	"dash_create_saving": "Saqlanmoqda...",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tasks",
 	"private": true,
-	"version": "0.59.0",
+	"version": "0.60.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {
@@ -116,7 +116,7 @@
 		"@tailwindcss/forms": "^0.5.11",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.2.2",
-		"@types/node": "^25.5.2",
+		"@types/node": "^25.6.0",
 		"@vitest/browser-playwright": "^4.1.4",
 		"@vitest/coverage-v8": "^4.1.4",
 		"better-auth": "~1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
     devDependencies:
       '@better-auth/cli':
         specifier: ~1.4.21
-        version: 1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@types/better-sqlite3@7.6.13)(better-call@1.1.8(zod@4.3.6))(drizzle-kit@0.31.10)(jose@6.2.2)(kysely@0.28.15)(magicast@0.5.2)(mongodb@7.1.0(socks@2.8.7))(nanostores@1.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
+        version: 1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@types/better-sqlite3@7.6.13)(better-call@1.1.8(zod@4.3.6))(drizzle-kit@0.31.10)(jose@6.2.2)(kysely@0.28.15)(magicast@0.5.2)(mongodb@7.1.0(socks@2.8.7))(nanostores@1.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
       '@chromatic-com/storybook':
         specifier: ^5.1.1
         version: 5.1.1(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -60,28 +60,28 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-docs':
         specifier: ^10.3.5
-        version: 10.3.5(@types/react@19.2.10)(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.5(@types/react@19.2.10)(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-svelte-csf':
         specifier: ^5.1.2
-        version: 5.1.2(@storybook/svelte@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2))(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.1.2(@storybook/svelte@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2))(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: ^10.3.5
         version: 10.3.5(@vitest/browser-playwright@4.1.4)(@vitest/browser@4.1.4)(@vitest/runner@4.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.4)
       '@storybook/sveltekit':
         specifier: ^10.3.5
-        version: 10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@stylistic/eslint-plugin':
         specifier: ^5.10.0
         version: 5.10.0(eslint@10.2.0(jiti@2.6.1))
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.8
-        version: 7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(wrangler@4.81.1(@cloudflare/workers-types@4.20260409.1))
+        version: 7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(wrangler@4.81.1(@cloudflare/workers-types@4.20260409.1))
       '@sveltejs/kit':
         specifier: ^2.57.1
-        version: 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
-        version: 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.2)
@@ -90,19 +90,19 @@ importers:
         version: 0.5.19(tailwindcss@4.2.2)
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@vitest/browser-playwright':
         specifier: ^4.1.4
-        version: 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       better-auth:
         specifier: ~1.6.2
-        version: 1.6.2(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
+        version: 1.6.2(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
       cspell:
         specifier: ^9
         version: 9.8.0
@@ -186,13 +186,13 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-devtools-json:
         specifier: ^1.0.0
-        version: 1.0.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest-browser-svelte:
         specifier: ^2.1.0
         version: 2.1.0(svelte@5.55.2)(vitest@4.1.4)
@@ -2382,8 +2382,8 @@ packages:
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -4746,8 +4746,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -5290,7 +5290,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/cli@1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@types/better-sqlite3@7.6.13)(better-call@1.1.8(zod@4.3.6))(drizzle-kit@0.31.10)(jose@6.2.2)(kysely@0.28.15)(magicast@0.5.2)(mongodb@7.1.0(socks@2.8.7))(nanostores@1.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)':
+  '@better-auth/cli@1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@types/better-sqlite3@7.6.13)(better-call@1.1.8(zod@4.3.6))(drizzle-kit@0.31.10)(jose@6.2.2)(kysely@0.28.15)(magicast@0.5.2)(mongodb@7.1.0(socks@2.8.7))(nanostores@1.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -5302,7 +5302,7 @@ snapshots:
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/client': 5.22.0
       '@types/pg': 8.20.0
-      better-auth: 1.4.21(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
+      better-auth: 1.4.21(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4)
       better-sqlite3: 12.8.0
       c12: 3.3.4(magicast@0.5.2)
       chalk: 5.6.2
@@ -6565,10 +6565,10 @@ snapshots:
       axe-core: 4.11.2
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.10)(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.10)(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.10)(react@19.2.5)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.5
@@ -6582,11 +6582,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2))(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2))(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@storybook/csf': 0.1.13
       '@storybook/svelte': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)
-      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       dedent: 1.7.2
       es-toolkit: 1.45.1
       esrap: 1.4.9
@@ -6594,7 +6594,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       svelte: 5.55.2
       svelte-ast-print: 0.4.2(svelte@5.55.2)
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -6605,33 +6605,33 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/runner': 4.1.4
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
       rollup: 4.59.0
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -6650,17 +6650,17 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/svelte-vite@10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/svelte-vite@10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/svelte': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)
-      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       magic-string: 0.30.21
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       svelte: 5.55.2
       svelte2tsx: 0.7.53(svelte@5.55.2)(typescript@5.9.3)
       typescript: 5.9.3
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -6673,14 +6673,14 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
 
-  '@storybook/sveltekit@10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/sveltekit@10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/svelte': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)
-      '@storybook/svelte-vite': 10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/svelte-vite': 10.3.5(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       svelte: 5.55.2
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@sveltejs/vite-plugin-svelte'
       - esbuild
@@ -6701,18 +6701,18 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(wrangler@4.81.1(@cloudflare/workers-types@4.20260409.1))':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(wrangler@4.81.1(@cloudflare/workers-types@4.20260409.1))':
     dependencies:
       '@cloudflare/workers-types': 4.20260409.1
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       worktop: 0.8.0-next.18
       wrangler: 4.81.1(@cloudflare/workers-types@4.20260409.1)
 
-  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 1.1.1
@@ -6724,19 +6724,19 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.55.2
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       typescript: 6.0.2
 
-  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.55.2
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@tailwindcss/forms@0.5.11(tailwindcss@4.2.2)':
     dependencies:
@@ -6809,12 +6809,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -6853,7 +6853,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
     optional: true
 
   '@types/chai@5.2.3':
@@ -6877,13 +6877,13 @@ snapshots:
 
   '@types/mdx@2.0.13': {}
 
-  '@types/node@25.5.2':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -6905,7 +6905,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
@@ -7088,29 +7088,29 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -7130,9 +7130,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7151,13 +7151,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7250,7 +7250,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.17: {}
 
-  better-auth@1.4.21(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4):
+  better-auth@1.4.21(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4):
     dependencies:
       '@better-auth/core': 1.4.21(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/telemetry': 1.4.21(@better-auth/core@1.4.21(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))
@@ -7266,7 +7266,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@prisma/client': 5.22.0
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       better-sqlite3: 12.8.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)
@@ -7275,9 +7275,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       svelte: 5.55.2
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  better-auth@1.6.2(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4):
+  better-auth@1.6.2(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))(mongodb@7.1.0(socks@2.8.7))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.55.2)(vitest@4.1.4):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260409.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0))
@@ -7298,7 +7298,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@prisma/client': 5.22.0
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.2)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       better-sqlite3: 12.8.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260409.1)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)
@@ -7307,7 +7307,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       svelte: 5.55.2
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9130,7 +9130,7 @@ snapshots:
 
   typescript@6.0.2: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   undici@7.24.4: {}
 
@@ -9217,12 +9217,12 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
 
-  vite-plugin-devtools-json@1.0.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-devtools-json@1.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       uuid: 11.1.0
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9230,28 +9230,28 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitefu@1.1.3(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vitest-browser-svelte@2.1.0(svelte@5.55.2)(vitest@4.1.4):
     dependencies:
       '@playwright/test': 1.59.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.2)
       svelte: 5.55.2
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -9268,12 +9268,12 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 25.5.2
-      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
     transitivePeerDependencies:
       - msw

--- a/src/lib/components/dash/DashCreateFormState.svelte.ts
+++ b/src/lib/components/dash/DashCreateFormState.svelte.ts
@@ -72,19 +72,18 @@ export class DashCreateFormState {
 	}
 
 	add_label(name: string): void {
-		const trimmed = name.trim()
-
-		if (trimmed && !this.form_selected_labels.includes(trimmed)) {
-			this.form_selected_labels = [...this.form_selected_labels, trimmed]
-		}
-
+		this.form_selected_labels = dash_task_form_shared.apply_add_label(
+			this.form_selected_labels,
+			name,
+		)
 		this.form_label_input = ''
 	}
 
 	toggle_label_name(name: string): void {
-		this.form_selected_labels = this.form_selected_labels.includes(name)
-			? this.form_selected_labels.filter((label_name) => label_name !== name)
-			: [...this.form_selected_labels, name]
+		this.form_selected_labels = dash_task_form_shared.apply_toggle_label(
+			this.form_selected_labels,
+			name,
+		)
 	}
 
 	handle_label_keydown(key_event: KeyboardEvent): void {

--- a/src/lib/components/dash/DashCreateTaskForm.svelte
+++ b/src/lib/components/dash/DashCreateTaskForm.svelte
@@ -3,16 +3,12 @@
 	import { enhance } from '$app/forms'
 	import RecurrenceInput from '$lib/components/RecurrenceInput.svelte'
 	import Spinner from '$lib/components/Spinner.svelte'
-	import { dash_display } from '$lib/dash-display'
 	import type { ActionData, PageData } from '$lib/dash-page-types'
 	import { m } from '$lib/paraglide/messages'
 	import { tick } from 'svelte'
-	import {
-		dash_task_form_shared,
-		DIALOG_RECURRENCE_CLASS,
-		LABEL_BLUR_DELAY_MS,
-	} from './dash-task-form-shared'
+	import { dash_task_form_shared, DIALOG_RECURRENCE_CLASS } from './dash-task-form-shared'
 	import { DashCreateFormState } from './DashCreateFormState.svelte'
+	import DashTaskLabelPicker from './DashTaskLabelPicker.svelte'
 
 	interface Props {
 		data: PageData
@@ -105,81 +101,26 @@
 	></textarea>
 
 	<div class="space-y-1.5">
-		{#each state.form_selected_labels as hidden_label (hidden_label)}
-			<input type="hidden" name="labels" value={hidden_label} />
-		{/each}
-		{#if data.labels.length > 0 || state.pending_new_label_names.length > 0}
-			<div class="flex flex-wrap gap-1.5">
-				{#each data.labels as label_row (label_row.id)}
-					<button
-						type="button"
-						onclick={() => {
-							state.toggle_label_name(label_row.name)
-						}}
-						class={dash_display.label_chip_filter_class(
-							label_row.name,
-							state.form_selected_labels.includes(label_row.name),
-						)}
-					>
-						{label_row.name}
-					</button>
-				{/each}
-				{#each state.pending_new_label_names as new_label (new_label)}
-					<span
-						class="{dash_display.label_chip_filter_class(
-							new_label,
-							true,
-						)} inline-flex items-center gap-1"
-					>
-						{new_label}
-						<button
-							type="button"
-							aria-label="Remove label"
-							onclick={() => {
-								state.form_selected_labels = state.form_selected_labels.filter(
-									(name) => name !== new_label,
-								)
-							}}
-							class="leading-none">×</button
-						>
-					</span>
-				{/each}
-			</div>
-		{/if}
-		<div class="relative">
-			<input
-				type="text"
-				bind:value={state.form_label_input}
-				onkeydown={(key_event: KeyboardEvent) => {
-					state.handle_label_keydown(key_event)
-				}}
-				onfocus={() => (state.is_form_label_focused = true)}
-				onblur={() => {
-					setTimeout(() => {
-						state.is_form_label_focused = false
-					}, LABEL_BLUR_DELAY_MS)
-				}}
-				placeholder={m.dash_create_label_placeholder()}
-				class={input_class}
-			/>
-			{#if state.is_form_label_focused && state.label_suggestions.length > 0}
-				<div
-					class="absolute top-full z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800"
-				>
-					{#each state.label_suggestions as suggestion (suggestion.id)}
-						<button
-							type="button"
-							class="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700"
-							onclick={() => {
-								state.add_label(suggestion.name)
-							}}
-						>
-							{suggestion.name}
-						</button>
-					{/each}
-				</div>
-			{/if}
-		</div>
+		<DashTaskLabelPicker
+			all_labels={data.labels}
+			selected_labels={state.form_selected_labels}
+			bind:label_input={state.form_label_input}
+			{input_class}
+			on_toggle={(name: string) => {
+				state.toggle_label_name(name)
+			}}
+			on_add={(name: string) => {
+				state.add_label(name)
+			}}
+			on_remove_pending={(name: string) => {
+				state.form_selected_labels = state.form_selected_labels.filter(
+					(label_name) => label_name !== name,
+				)
+			}}
+			on_keydown={(key_event: KeyboardEvent) => {
+				state.handle_label_keydown(key_event)
+			}}
+		/>
 	</div>
 
 	<input

--- a/src/lib/components/dash/DashInlineEditorBaseState.svelte.ts
+++ b/src/lib/components/dash/DashInlineEditorBaseState.svelte.ts
@@ -1,0 +1,330 @@
+/* eslint-disable unicorn/prevent-abbreviations, sonarjs/void-use, @typescript-eslint/no-floating-promises, promise/catch-or-return, promise/always-return -- DOM measurement and $effect tick scheduling */
+import type { PageData, TaskItem } from '$lib/dash-page-types'
+import { tick } from 'svelte'
+import {
+	ATTR_RR_ENH_GRACE_UNTIL,
+	dash_inline_editor_helpers,
+	RR_POST_MODAL_FOCUS_MS,
+} from './dash-inline-editor-helpers'
+import { dash_task_form_shared } from './dash-task-form-shared'
+
+const RR_CLOSE_BLUR_GRACE_MS = 2500
+const MS_PER_SECOND = 1000
+const SECONDS_PER_HOUR = 3600
+const RR_OPEN_ENH_BLOCK_MS = SECONDS_PER_HOUR * MS_PER_SECOND
+const RR_CLOSE_ENH_CANCEL_MS = 600
+
+export class DashInlineEditorBaseState {
+	readonly #get_task_item: () => TaskItem
+	readonly #get_labels: () => PageData['labels']
+	form_element = $state<HTMLFormElement | undefined>()
+	title_input_el = $state<HTMLInputElement | undefined>()
+	detail_textarea_el = $state<HTMLTextAreaElement | undefined>()
+	due_picker_input_el = $state<HTMLInputElement | undefined>()
+	recurrence_dialog_element = $state<HTMLDialogElement | undefined>()
+	is_date_picker_open = $state(false)
+	form_title = $state('')
+	form_detail = $state('')
+	form_label_input = $state('')
+	is_form_label_focused = $state(false)
+	form_selected_labels = $state<Array<string>>([])
+	form_due_date = $state('')
+	form_rrule = $state('')
+	rrule_draft = $state('')
+	recurrence_dialog_mount_key = $state(0)
+	is_form_saving = $state(false)
+	edit_error = $state<string | undefined>()
+	is_blur_commit_pending = $state(false)
+	submit_reason = $state<'normal' | 'title_enter_new'>('normal')
+	is_pointer_held = $state(false)
+	is_blur_deferred_to_pointer_up = $state(false)
+	last_seen_focus_request_id = $state(0)
+	blur_discard_timer: ReturnType<typeof globalThis.setTimeout> | undefined = undefined
+	rr_close_blur_grace_until_ms = 0
+	is_rr_dialog_session = false
+	is_rr_post_close_submit = false
+	is_arrow_nav_discard_active = false
+	is_navigating_away = false
+	last_seeded_task_id: string | undefined
+	pending_new_label_names = $derived.by(() =>
+		dash_task_form_shared.compute_pending_new_labels(this.form_selected_labels, this.#get_labels()),
+	)
+	label_suggestions = $derived.by(() =>
+		dash_task_form_shared.compute_label_suggestions(
+			this.form_label_input,
+			this.#get_labels(),
+			this.form_selected_labels,
+		),
+	)
+	due_display_text = $derived(dash_task_form_shared.format_due_date_display(this.form_due_date))
+	recurrence_edit_button_text = $derived(
+		dash_task_form_shared.format_recurrence_button_text(this.form_rrule),
+	)
+
+	constructor(get_task_item: () => TaskItem, get_labels: () => PageData['labels']) {
+		this.#get_task_item = get_task_item
+		this.#get_labels = get_labels
+
+		$effect(() => {
+			void this.form_detail
+			void this.detail_textarea_el
+			tick().then(() => {
+				dash_task_form_shared.sync_textarea_height(this.detail_textarea_el)
+			})
+		})
+
+		$effect(() => {
+			return () => {
+				this.clear_blur_discard_timer()
+				this.is_blur_deferred_to_pointer_up = false
+			}
+		})
+
+		$effect(() => {
+			const { id } = get_task_item()
+			if (id === this.last_seeded_task_id) return
+			this.last_seeded_task_id = id
+
+			this.sync_form_from_task_item()
+			this.#focus_inline_title_at_end()
+			tick().then(() => {
+				dash_task_form_shared.sync_textarea_height(this.detail_textarea_el)
+				this.#focus_inline_title_at_end()
+			})
+		})
+	}
+
+	get_task_item(): TaskItem {
+		return this.#get_task_item()
+	}
+
+	sync_form_from_task_item(): void {
+		const task = this.#get_task_item()
+
+		this.is_blur_commit_pending = false
+		this.is_navigating_away = false
+		this.form_title = task.title
+		this.form_detail = task.detail ?? ''
+		this.form_label_input = ''
+		this.form_selected_labels = task.task_labels.map((row) => row.label.name)
+		this.form_due_date = task.due_date ?? ''
+		this.form_rrule = task.recurrence_rule ?? ''
+		this.edit_error = undefined
+	}
+
+	revert_to_task_item(): void {
+		const task = this.#get_task_item()
+
+		this.form_title = task.title
+		this.form_detail = task.detail ?? ''
+		this.form_label_input = ''
+		this.form_selected_labels = task.task_labels.map((row) => row.label.name)
+		this.form_due_date = task.due_date ?? ''
+		this.form_rrule = task.recurrence_rule ?? ''
+		this.edit_error = undefined
+	}
+
+	is_form_dirty(): boolean {
+		const task = this.#get_task_item()
+
+		return dash_task_form_shared.is_inline_form_dirty(
+			{
+				title: this.form_title,
+				detail: this.form_detail,
+				selected_labels: this.form_selected_labels,
+				due_date: this.form_due_date,
+				rrule: this.form_rrule,
+			},
+			task,
+		)
+	}
+
+	is_never_titled_row(): boolean {
+		return !this.#get_task_item().title.trim()
+	}
+
+	add_label(name: string): void {
+		this.form_selected_labels = dash_task_form_shared.apply_add_label(
+			this.form_selected_labels,
+			name,
+		)
+		this.form_label_input = ''
+	}
+
+	commit_pending_label_input(): void {
+		if (this.form_label_input.trim()) this.add_label(this.form_label_input)
+	}
+
+	toggle_label_name(name: string): void {
+		this.form_selected_labels = dash_task_form_shared.apply_toggle_label(
+			this.form_selected_labels,
+			name,
+		)
+	}
+
+	handle_label_keydown(key_event: KeyboardEvent): void {
+		if (key_event.key !== 'Enter' || key_event.isComposing) return
+
+		key_event.preventDefault()
+		key_event.stopPropagation()
+
+		const host = key_event.currentTarget
+		const draft = (host instanceof HTMLInputElement ? host.value : this.form_label_input).trim()
+		if (draft) this.add_label(draft)
+	}
+
+	clear_blur_discard_timer(): void {
+		if (this.blur_discard_timer === undefined) return
+
+		globalThis.clearTimeout(this.blur_discard_timer)
+		this.blur_discard_timer = undefined
+	}
+
+	is_due_input_focused(): boolean {
+		return (
+			this.due_picker_input_el !== undefined && document.activeElement === this.due_picker_input_el
+		)
+	}
+
+	is_blocking_interaction_active(): boolean {
+		return this.is_dialog_open() || this.is_form_saving || this.is_date_picker_open
+	}
+
+	is_rr_blur_block_active(): boolean {
+		if (this.is_rr_dialog_session) return true
+		if (globalThis.performance.now() < this.rr_close_blur_grace_until_ms) return true
+
+		return false
+	}
+
+	should_abort_blur_commit(): boolean {
+		if (this.is_rr_blur_block_active()) return true
+		if (this.form_element?.contains(document.activeElement)) return true
+		if (this.is_due_input_focused()) return true
+
+		return this.is_blocking_interaction_active()
+	}
+
+	is_dialog_open(): boolean {
+		if (dash_inline_editor_helpers.is_live_open_dialog(this.recurrence_dialog_element)) return true
+
+		return dash_inline_editor_helpers.is_live_open_dialog(
+			dash_inline_editor_helpers.read_rr_dialog_from_dom(this.form_element),
+		)
+	}
+
+	close_dialogs(): void {
+		this.recurrence_dialog_element?.close()
+	}
+
+	#resolve_inline_task_form(anchor?: HTMLElement): HTMLFormElement | undefined {
+		const from_anchor = dash_inline_editor_helpers.task_form_from_host(anchor)
+		if (from_anchor !== undefined) return from_anchor
+
+		const from_title = dash_inline_editor_helpers.task_form_from_host(this.title_input_el)
+		if (from_title !== undefined) return from_title
+
+		const from_dialog = dash_inline_editor_helpers.task_form_from_host(
+			this.recurrence_dialog_element,
+		)
+		if (from_dialog !== undefined) return from_dialog
+
+		return this.form_element
+	}
+
+	write_rr_enhance_grace_ms(duration_ms: number, anchor?: HTMLElement): void {
+		const el = this.#resolve_inline_task_form(anchor)
+
+		dash_inline_editor_helpers.write_rr_enhance_grace_ms(el, duration_ms)
+	}
+
+	open_recurrence_dialog(anchor?: HTMLElement): void {
+		this.write_rr_enhance_grace_ms(RR_OPEN_ENH_BLOCK_MS, anchor)
+		this.rrule_draft = this.form_rrule
+		this.recurrence_dialog_mount_key += 1
+		this.is_rr_dialog_session = true
+		this.recurrence_dialog_element?.showModal()
+	}
+
+	close_rr_dialog_ui(anchor?: HTMLElement): void {
+		this.write_rr_enhance_grace_ms(RR_CLOSE_ENH_CANCEL_MS, anchor)
+		this.rr_close_blur_grace_until_ms = globalThis.performance.now() + RR_CLOSE_BLUR_GRACE_MS
+		this.recurrence_dialog_element?.close()
+	}
+
+	submit_dirty_if_rr_idle(): void {
+		this.commit_pending_label_input()
+		this.clear_blur_discard_timer()
+
+		if (!this.is_form_saving && this.form_title.trim() !== '' && this.is_form_dirty()) {
+			this.is_blur_commit_pending = false
+			this.submit_reason = 'normal'
+			this.is_rr_post_close_submit = true
+			this.form_element?.requestSubmit()
+		}
+	}
+
+	async handle_recurrence_dialog_close(): Promise<void> {
+		this.clear_blur_discard_timer()
+		this.is_blur_deferred_to_pointer_up = false
+		this.form_rrule = this.rrule_draft
+		this.write_rr_enhance_grace_ms(RR_CLOSE_ENH_CANCEL_MS)
+		this.rr_close_blur_grace_until_ms = globalThis.performance.now() + RR_CLOSE_BLUR_GRACE_MS
+		await this.#focus_title_after_rr_close()
+		await this.#end_rr_session_clear_enhance()
+		await tick()
+		await dash_inline_editor_helpers.next_animation_frame()
+		this.submit_dirty_if_rr_idle()
+	}
+
+	#focus_inline_title_at_end(): void {
+		const el = this.title_input_el
+		if (!el) return
+
+		el.focus()
+		el.setSelectionRange(el.value.length, el.value.length)
+	}
+
+	async refocus_title_through_churn(): Promise<void> {
+		const target = dash_inline_editor_helpers.resolve_title_focus_target(
+			this.title_input_el,
+			this.form_element,
+		)
+
+		target?.focus()
+
+		await new Promise<void>((resolve) => {
+			globalThis.setTimeout(() => {
+				dash_inline_editor_helpers
+					.resolve_title_focus_target(this.title_input_el, this.form_element)
+					?.focus()
+				resolve()
+			}, 0)
+		})
+
+		await new Promise<void>((resolve) => {
+			globalThis.setTimeout(() => {
+				dash_inline_editor_helpers
+					.resolve_title_focus_target(this.title_input_el, this.form_element)
+					?.focus()
+				resolve()
+			}, RR_POST_MODAL_FOCUS_MS)
+		})
+	}
+
+	async #focus_title_after_rr_close(): Promise<void> {
+		await tick()
+		await dash_inline_editor_helpers.next_animation_frame()
+		await dash_inline_editor_helpers.next_animation_frame()
+		await this.refocus_title_through_churn()
+		await dash_inline_editor_helpers.next_animation_frame()
+	}
+
+	async #end_rr_session_clear_enhance(): Promise<void> {
+		this.is_rr_dialog_session = false
+		this.rr_close_blur_grace_until_ms = 0
+		this.form_element?.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
+		await tick()
+		await dash_inline_editor_helpers.next_animation_frame()
+	}
+}

--- a/src/lib/components/dash/DashInlineEditorState.svelte.ts
+++ b/src/lib/components/dash/DashInlineEditorState.svelte.ts
@@ -1,0 +1,357 @@
+/* eslint-disable unicorn/prevent-abbreviations -- DOM measurement and $effect tick scheduling */
+import type { ActionResult, SubmitFunction } from '@sveltejs/kit'
+import { dash_inline_editor_keyboard } from '$lib/dash-inline-editor-keyboard'
+import type { PageData, TaskItem } from '$lib/dash-page-types'
+import { tick } from 'svelte'
+import { ATTR_RR_ENH_GRACE_UNTIL, dash_inline_editor_helpers } from './dash-inline-editor-helpers'
+import {
+	BLUR_COMMIT_DELAY_MS,
+	dash_task_form_shared,
+	POINTER_UP_SETTLE_MS,
+} from './dash-task-form-shared'
+import { DashInlineEditorBaseState } from './DashInlineEditorBaseState.svelte'
+
+type UpdateFn = (options?: { reset?: boolean }) => Promise<void>
+
+interface EditorCallbackGetters {
+	get_on_escape: () => () => void
+	get_on_saved: () => () => Promise<void>
+	get_on_blur_commit_saved: () => (() => Promise<void>) | undefined
+	get_on_title_enter_saved: () => (() => Promise<void>) | undefined
+	get_on_try_discard_empty: () => (() => Promise<void>) | undefined
+	get_on_navigate_arrow: () => ((direction: 'up' | 'down') => void) | undefined
+}
+
+export class DashInlineEditorState extends DashInlineEditorBaseState {
+	readonly #cbs: EditorCallbackGetters
+
+	constructor(
+		get_task_item: () => TaskItem,
+		get_labels: () => PageData['labels'],
+		callbacks: EditorCallbackGetters,
+	) {
+		super(get_task_item, get_labels)
+		this.#cbs = callbacks
+	}
+
+	handle_form_focusout(focus_event: FocusEvent): void {
+		if (this.#should_skip_form_focusout(focus_event)) return
+
+		this.clear_blur_discard_timer()
+
+		if (this.is_pointer_held) {
+			this.is_blur_deferred_to_pointer_up = true
+
+			return
+		}
+
+		const delay_ms = dash_inline_editor_helpers.is_switching_to_other_task(
+			focus_event.relatedTarget,
+			this.get_task_item().id,
+		)
+			? 0
+			: BLUR_COMMIT_DELAY_MS
+
+		this.blur_discard_timer = globalThis.setTimeout(() => {
+			this.blur_discard_timer = undefined
+			void this.#run_deferred_blur_commit()
+		}, delay_ms)
+	}
+
+	handle_document_pointerdown(): void {
+		this.is_pointer_held = true
+	}
+
+	async handle_document_pointerup(): Promise<void> {
+		this.is_pointer_held = false
+
+		if (!this.is_blur_deferred_to_pointer_up) return
+
+		this.is_blur_deferred_to_pointer_up = false
+		await new Promise((resolve) => {
+			globalThis.setTimeout(resolve, POINTER_UP_SETTLE_MS)
+		})
+		await this.#run_deferred_blur_commit()
+	}
+
+	handle_document_pointercancel(): void {
+		this.is_pointer_held = false
+		this.is_blur_deferred_to_pointer_up = false
+	}
+
+	handle_document_keydown(key_event: KeyboardEvent): void {
+		if (key_event.key !== 'Escape' || key_event.isComposing) return
+		if (this.is_dialog_open()) return
+
+		key_event.preventDefault()
+		this.#apply_escape_key_outcome()
+	}
+
+	handle_title_keydown(key_event: KeyboardEvent): void {
+		if (dash_inline_editor_keyboard.read_vertical_arrow_direction(key_event) !== undefined) {
+			this.#handle_arrow_navigation(key_event)
+
+			return
+		}
+
+		if (key_event.key !== 'Enter' || key_event.shiftKey || key_event.isComposing) return
+
+		this.#handle_title_enter_confirm(key_event)
+	}
+
+	handle_detail_keydown(key_event: KeyboardEvent): void {
+		if (key_event.key === 'Enter' && !key_event.shiftKey && !key_event.isComposing) {
+			key_event.preventDefault()
+			this.#try_submit_form()
+		}
+	}
+
+	open_due_picker(): void {
+		const picker = this.due_picker_input_el
+		if (!picker) return
+
+		this.is_date_picker_open = true
+
+		if (typeof picker.showPicker === 'function') {
+			picker.showPicker()
+		} else {
+			picker.click()
+		}
+	}
+
+	get_enhance_callback(): SubmitFunction {
+		return (submission) => {
+			const { formElement: form_element, cancel } = submission
+			const should_cancel =
+				dash_inline_editor_helpers.is_rr_enhance_grace_active_on(form_element) ||
+				this.is_rr_blur_block_active() ||
+				(this.is_dialog_open() && !this.is_rr_post_close_submit)
+
+			if (should_cancel) {
+				cancel()
+
+				return this.#handle_update_enhance_result.bind(this)
+			}
+
+			this.is_rr_post_close_submit = false
+			form_element.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
+			this.clear_blur_discard_timer()
+			this.is_form_saving = true
+
+			return this.#handle_update_enhance_result.bind(this)
+		}
+	}
+
+	#should_skip_form_focusout(focus_event: FocusEvent): boolean {
+		const related_target = focus_event.relatedTarget
+		const related = related_target instanceof Node ? related_target : undefined
+		if (dash_task_form_shared.is_focus_still_inside_form(this.form_element, related)) return true
+		if (dash_inline_editor_helpers.is_rr_dialog_null_focusout(focus_event)) return true
+		if (globalThis.performance.now() < this.rr_close_blur_grace_until_ms) return true
+
+		return this.is_rr_dialog_session
+	}
+
+	async #run_deferred_blur_commit(): Promise<void> {
+		if (this.should_abort_blur_commit()) return
+
+		if (!this.form_title.trim()) {
+			await this.#commit_blur_when_title_missing()
+
+			return
+		}
+
+		if (this.is_form_dirty()) {
+			this.#apply_dirty_blur_submit()
+
+			return
+		}
+
+		if (this.is_navigating_away) return
+
+		this.#cbs.get_on_escape()()
+	}
+
+	async #commit_blur_when_title_missing(): Promise<void> {
+		if (!this.is_never_titled_row()) {
+			this.revert_to_task_item()
+
+			return
+		}
+
+		await this.#apply_empty_blur_outcome()
+	}
+
+	#apply_dirty_blur_submit(): void {
+		if (this.is_rr_blur_block_active()) return
+
+		this.commit_pending_label_input()
+		this.is_blur_commit_pending = true
+		this.submit_reason = 'normal'
+		this.form_element?.requestSubmit()
+	}
+
+	async #apply_empty_blur_outcome(): Promise<void> {
+		if (dash_inline_editor_helpers.is_node_inside_add_task_region(document.activeElement)) return
+		if (this.is_arrow_nav_discard_active) return
+
+		const discard = this.#cbs.get_on_try_discard_empty()
+		if (discard !== undefined) await discard()
+	}
+
+	#apply_escape_key_outcome(): void {
+		this.close_dialogs()
+
+		const should_discard = !this.form_title.trim() && this.is_never_titled_row()
+
+		if (should_discard) {
+			void this.#cbs.get_on_try_discard_empty()?.()
+
+			return
+		}
+
+		this.revert_to_task_item()
+		this.#cbs.get_on_escape()()
+	}
+
+	#try_submit_form(): void {
+		if (this.is_rr_blur_block_active()) return
+		if (this.is_form_saving || this.form_title.trim() === '') return
+
+		this.commit_pending_label_input()
+		this.clear_blur_discard_timer()
+		this.is_blur_commit_pending = false
+		this.submit_reason = 'normal'
+		this.form_element?.requestSubmit()
+	}
+
+	#handle_title_enter_confirm(key_event: KeyboardEvent): void {
+		key_event.preventDefault()
+		if (this.is_rr_blur_block_active() || this.is_form_saving || !this.form_title.trim()) return
+
+		this.clear_blur_discard_timer()
+		this.is_blur_commit_pending = false
+		this.submit_reason = 'title_enter_new'
+		this.form_element?.requestSubmit()
+	}
+
+	#handle_arrow_navigation(key_event: KeyboardEvent): void {
+		if (key_event.isComposing) return
+
+		const direction = dash_inline_editor_keyboard.read_vertical_arrow_direction(key_event)
+		if (direction === undefined) return
+
+		key_event.preventDefault()
+
+		if (this.form_title.trim()) {
+			this.#handle_arrow_with_title(direction)
+		} else {
+			this.#handle_arrow_without_title(direction)
+		}
+	}
+
+	#handle_arrow_without_title(direction: 'up' | 'down'): void {
+		if (!this.is_never_titled_row()) this.revert_to_task_item()
+
+		this.is_navigating_away = true
+		this.#cbs.get_on_navigate_arrow()?.(direction)
+
+		if (this.is_never_titled_row()) {
+			this.is_arrow_nav_discard_active = true
+			void this.#cbs.get_on_try_discard_empty()?.()
+		}
+	}
+
+	#handle_arrow_with_title(direction: 'up' | 'down'): void {
+		if (this.is_form_dirty()) this.#try_submit_form()
+
+		this.is_navigating_away = true
+		this.#cbs.get_on_navigate_arrow()?.(direction)
+	}
+
+	async #handle_update_enhance_result(input: {
+		result: ActionResult
+		update: UpdateFn
+	}): Promise<void> {
+		this.is_form_saving = false
+
+		const reason = this.submit_reason
+
+		this.submit_reason = 'normal'
+
+		if (input.result.type === 'success') {
+			const is_saved_via_blur_commit = this.is_blur_commit_pending
+
+			await this.#finalize_success_then_refocus(reason, is_saved_via_blur_commit, input.update)
+
+			return
+		}
+
+		this.is_blur_commit_pending = false
+		this.edit_error = dash_task_form_shared.read_action_error(input.result)
+		await input.update({ reset: false })
+	}
+
+	async #finalize_success_then_refocus(
+		reason: 'normal' | 'title_enter_new',
+		is_saved_via_blur_commit: boolean,
+		update: UpdateFn,
+	): Promise<void> {
+		this.close_dialogs()
+		this.edit_error = undefined
+		this.is_blur_commit_pending = false
+		this.#reset_blur_defer_flags()
+		await update({ reset: false })
+		this.#reset_blur_defer_flags()
+		await tick()
+		this.sync_form_from_task_item()
+		await this.#run_after_successful_update(reason, is_saved_via_blur_commit)
+		this.#reset_blur_defer_flags()
+		await this.#maybe_refocus_title(reason, is_saved_via_blur_commit)
+	}
+
+	async #run_after_successful_update(
+		reason: 'normal' | 'title_enter_new',
+		is_saved_via_blur_commit: boolean,
+	): Promise<void> {
+		if (reason === 'title_enter_new') {
+			await this.#cbs.get_on_title_enter_saved()?.()
+
+			return
+		}
+
+		if (is_saved_via_blur_commit) {
+			const on_blur = this.#cbs.get_on_blur_commit_saved()
+
+			if (on_blur !== undefined) {
+				await on_blur()
+
+				return
+			}
+		}
+
+		await this.#cbs.get_on_saved()()
+	}
+
+	async #maybe_refocus_title(
+		reason: 'normal' | 'title_enter_new',
+		is_saved_via_blur_commit: boolean,
+	): Promise<void> {
+		const is_blur_exit =
+			reason === 'normal' &&
+			is_saved_via_blur_commit &&
+			this.#cbs.get_on_blur_commit_saved() !== undefined
+
+		if (is_blur_exit || this.is_navigating_away) return
+
+		await tick()
+		await dash_inline_editor_helpers.next_animation_frame()
+		await dash_inline_editor_helpers.next_animation_frame()
+		await this.refocus_title_through_churn()
+	}
+
+	#reset_blur_defer_flags(): void {
+		this.clear_blur_discard_timer()
+		this.is_blur_deferred_to_pointer_up = false
+	}
+}

--- a/src/lib/components/dash/DashInlineEditorState.svelte.ts
+++ b/src/lib/components/dash/DashInlineEditorState.svelte.ts
@@ -129,14 +129,12 @@ export class DashInlineEditorState extends DashInlineEditorBaseState {
 
 			if (should_cancel) {
 				cancel()
-
-				return this.#handle_update_enhance_result.bind(this)
+			} else {
+				this.is_rr_post_close_submit = false
+				form_element.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
+				this.clear_blur_discard_timer()
+				this.is_form_saving = true
 			}
-
-			this.is_rr_post_close_submit = false
-			form_element.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
-			this.clear_blur_discard_timer()
-			this.is_form_saving = true
 
 			return this.#handle_update_enhance_result.bind(this)
 		}
@@ -302,12 +300,11 @@ export class DashInlineEditorState extends DashInlineEditorBaseState {
 		this.is_blur_commit_pending = false
 		this.#reset_blur_defer_flags()
 		await update({ reset: false })
-		this.#reset_blur_defer_flags()
 		await tick()
 		this.sync_form_from_task_item()
 		await this.#run_after_successful_update(reason, is_saved_via_blur_commit)
-		this.#reset_blur_defer_flags()
 		await this.#maybe_refocus_title(reason, is_saved_via_blur_commit)
+		this.#reset_blur_defer_flags()
 	}
 
 	async #run_after_successful_update(

--- a/src/lib/components/dash/DashTaskInlineEditor.svelte
+++ b/src/lib/components/dash/DashTaskInlineEditor.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
-	/* eslint-disable max-lines, max-statements -- mirrors create form for inline edit */
-	/* eslint-disable unicorn/prevent-abbreviations, sonarjs/void-use, @typescript-eslint/no-floating-promises, promise/catch-or-return, promise/prefer-await-to-then, promise/always-return, unicorn/no-useless-undefined -- DOM measurement and $effect tick scheduling */
-	import type { ActionResult } from '@sveltejs/kit'
 	import { enhance } from '$app/forms'
 	import RecurrenceInput from '$lib/components/RecurrenceInput.svelte'
 	import Spinner from '$lib/components/Spinner.svelte'
-	import { dash_display } from '$lib/dash-display'
-	import { dash_inline_editor_keyboard } from '$lib/dash-inline-editor-keyboard'
 	import type { ActionData, PageData, TaskItem } from '$lib/dash-page-types'
 	import { m } from '$lib/paraglide/messages'
 	import { tick } from 'svelte'
 	import { slide } from 'svelte/transition'
-	import {
-		BLUR_COMMIT_DELAY_MS,
-		dash_task_form_shared,
-		DIALOG_RECURRENCE_CLASS,
-		LABEL_BLUR_DELAY_MS,
-		POINTER_UP_SETTLE_MS,
-	} from './dash-task-form-shared'
+	import { dash_task_form_shared, DIALOG_RECURRENCE_CLASS } from './dash-task-form-shared'
+	import { DashInlineEditorState } from './DashInlineEditorState.svelte'
+	import DashTaskLabelPicker from './DashTaskLabelPicker.svelte'
 
 	interface Props {
 		task_item: TaskItem
@@ -52,799 +43,57 @@
 		on_navigate_arrow,
 	}: Props = $props()
 
-	const rr_close_blur_grace_ms = 2500
-	const MS_PER_SECOND = 1000
-	const SECONDS_PER_HOUR = 3600
-	/** Block `use:enhance` submits while the recurrence modal is open (Svelte may keep a stale enhance callback). */
-	const RR_OPEN_ENH_BLOCK_MS = SECONDS_PER_HOUR * MS_PER_SECOND
-	/** Brief window after closing the modal to cancel spurious submits; intentional save can follow soon after. */
-	const RR_CLOSE_ENH_CANCEL_MS = 600
-	const ATTR_RR_ENH_GRACE_UNTIL = 'data-dash-rr-enhance-grace-until'
-	const SELECTOR_DASH_RR_DIALOG = '[data-testid="dash-recurrence-dialog"]'
-	const SELECTOR_INLINE_TITLE = '[data-testid="dash-inline-title-input"]'
-	/** After `HTMLDialogElement.close()` or `invalidateAll`, focus may be reset after our first `focus()`. */
-	const RR_POST_MODAL_FOCUS_MS = 100
-
-	let form_element = $state<HTMLFormElement | undefined>()
-	let title_input_el = $state<HTMLInputElement | undefined>()
-	let detail_textarea_el = $state<HTMLTextAreaElement | undefined>()
-	let due_picker_input_el = $state<HTMLInputElement | undefined>()
-	let is_date_picker_open = $state(false)
-
-	let form_title = $state('')
-	let form_detail = $state('')
-	let form_label_input = $state('')
-	let is_form_label_focused = $state(false)
-	let form_selected_labels = $state<Array<string>>([])
-	let form_due_date = $state('')
-	let form_rrule = $state('')
-	/** Edited inside the recurrence dialog; merged into `form_rrule` on dialog close only. */
-	let rrule_draft = $state('')
-	let recurrence_dialog_mount_key = $state(0)
-	let is_form_saving = $state(false)
-	let edit_error = $state<string | undefined>()
-	let recurrence_dialog_element = $state<HTMLDialogElement | undefined>()
-
-	let submit_reason = $state<'normal' | 'title_enter_new'>('normal')
-	let blur_discard_timer: ReturnType<typeof globalThis.setTimeout> | undefined = undefined
-	let is_blur_commit_pending = $state(false)
-	let is_pointer_held = $state(false)
-	let is_blur_deferred_to_pointer_up = $state(false)
-	let rr_close_blur_grace_until_ms = 0
-	/** True from opening the recurrence dialog until close (covers close() vs `open` timing). */
-	let is_rr_dialog_session = false
-	/** `HTMLDialogElement.open` can stay true for one frame after `close()`; still submit from `onclose`. */
-	let is_rr_post_close_submit = false
-	/** Prevents the focusout path from triggering a second discard when arrow navigation already handled it. */
-	let is_arrow_nav_discard_active = false
-	/** Set when arrow navigation is initiated so finalize_success_then_refocus skips stealing focus back. */
-	let is_navigating_away = false
-
-	function clear_blur_discard_timer(): void {
-		if (blur_discard_timer === undefined) return
-
-		globalThis.clearTimeout(blur_discard_timer)
-		blur_discard_timer = undefined
-	}
-
-	function is_node_inside_add_task_region(node: Node | null): boolean {
-		return node instanceof HTMLElement && Boolean(node.closest('[data-dash-add-task-region]'))
-	}
-
-	function blur_effect_cleanup(): void {
-		clear_blur_discard_timer()
-		is_blur_deferred_to_pointer_up = false
-	}
-
-	const label_sort_compare = (left: string, right: string): number => left.localeCompare(right)
-
-	function is_never_titled_row(): boolean {
-		return !task_item.title.trim()
-	}
-
-	function sorted_label_names_from_task(): Array<string> {
-		return task_item.task_labels.map((row) => row.label.name).toSorted(label_sort_compare)
-	}
-
-	function sorted_label_names_from_form(): Array<string> {
-		return [...form_selected_labels]
-			.map((name) => name.trim())
-			.filter(Boolean)
-			.toSorted(label_sort_compare)
-	}
-
-	function is_label_set_changed(): boolean {
-		return sorted_label_names_from_form().join('\0') !== sorted_label_names_from_task().join('\0')
-	}
-
-	function is_text_fields_changed(): boolean {
-		return (
-			form_title.trim() !== task_item.title.trim() ||
-			form_detail.trim() !== (task_item.detail ?? '').trim()
-		)
-	}
-
-	function is_schedule_changed(): boolean {
-		return (
-			form_due_date !== (task_item.due_date ?? '') ||
-			form_rrule !== (task_item.recurrence_rule ?? '')
-		)
-	}
-
-	function is_form_dirty(): boolean {
-		return is_text_fields_changed() || is_label_set_changed() || is_schedule_changed()
-	}
-
-	const pending_new_label_names = $derived(
-		dash_task_form_shared.compute_pending_new_labels(form_selected_labels, data.labels),
-	)
-
-	const label_suggestions = $derived(
-		dash_task_form_shared.compute_label_suggestions(
-			form_label_input,
-			data.labels,
-			form_selected_labels,
-		),
-	)
-
-	const due_display_text = $derived(dash_task_form_shared.format_due_date_display(form_due_date))
-
-	const recurrence_edit_button_text = $derived(
-		dash_task_form_shared.format_recurrence_button_text(form_rrule),
+	const state = new DashInlineEditorState(
+		() => task_item,
+		() => data.labels,
+		{
+			get_on_escape: () => on_escape,
+			get_on_saved: () => on_saved,
+			get_on_blur_commit_saved: () => on_blur_commit_saved,
+			get_on_title_enter_saved: () => on_title_enter_saved,
+			get_on_try_discard_empty: () => on_try_discard_empty,
+			get_on_navigate_arrow: () => on_navigate_arrow,
+		},
 	)
 
 	$effect(() => {
-		void form_detail
-		void detail_textarea_el
-		tick().then(() => {
-			dash_task_form_shared.sync_textarea_height(detail_textarea_el)
-		})
-	})
+		if (focus_request_id <= state.last_seen_focus_request_id) return
 
-	$effect(() => {
-		return blur_effect_cleanup
-	})
-
-	let last_seen_focus_request_id = $state(0)
-
-	let last_seeded_task_id = $state<string | undefined>(undefined)
-
-	function focus_inline_title_at_end(): void {
-		const el = title_input_el
-		if (!el) return
-
-		el.focus()
-		el.setSelectionRange(el.value.length, el.value.length)
-	}
-
-	function sync_form_from_task_item(): void {
-		is_blur_commit_pending = false
-		is_navigating_away = false
-		form_title = task_item.title
-		form_detail = task_item.detail ?? ''
-		form_label_input = ''
-		form_selected_labels = task_item.task_labels.map((row) => row.label.name)
-		form_due_date = task_item.due_date ?? ''
-		form_rrule = task_item.recurrence_rule ?? ''
-		edit_error = undefined
-	}
-
-	$effect(() => {
-		const { id } = task_item
-		if (id === last_seeded_task_id) return
-		last_seeded_task_id = id
-
-		sync_form_from_task_item()
-		focus_inline_title_at_end()
-		tick().then(() => {
-			dash_task_form_shared.sync_textarea_height(detail_textarea_el)
-			focus_inline_title_at_end()
-
-			return undefined
-		})
-	})
-
-	function add_label(name: string): void {
-		const trimmed = name.trim()
-
-		if (trimmed && !form_selected_labels.includes(trimmed)) {
-			form_selected_labels = [...form_selected_labels, trimmed]
-		}
-
-		form_label_input = ''
-	}
-
-	function commit_pending_label_input(): void {
-		if (form_label_input.trim()) add_label(form_label_input)
-	}
-
-	function toggle_label_name(name: string): void {
-		form_selected_labels = form_selected_labels.includes(name)
-			? form_selected_labels.filter((label_name) => label_name !== name)
-			: [...form_selected_labels, name]
-	}
-
-	function read_label_input_value(key_event: KeyboardEvent): string {
-		const host = key_event.currentTarget
-
-		return host instanceof HTMLInputElement ? host.value : form_label_input
-	}
-
-	function handle_label_keydown(key_event: KeyboardEvent): void {
-		if (key_event.key === 'Enter' && !key_event.isComposing) {
-			key_event.preventDefault()
-			key_event.stopPropagation()
-			const draft = read_label_input_value(key_event).trim()
-			if (draft) add_label(draft)
-		}
-	}
-
-	function revert_to_task_item(): void {
-		form_title = task_item.title
-		form_detail = task_item.detail ?? ''
-		form_label_input = ''
-		form_selected_labels = task_item.task_labels.map((row) => row.label.name)
-		form_due_date = task_item.due_date ?? ''
-		form_rrule = task_item.recurrence_rule ?? ''
-		edit_error = undefined
-	}
-
-	function close_dialogs(): void {
-		recurrence_dialog_element?.close()
-	}
-
-	function read_rr_dialog_from_dom(): HTMLDialogElement | undefined {
-		const host = form_element?.querySelector(SELECTOR_DASH_RR_DIALOG)
-
-		return host instanceof HTMLDialogElement ? host : undefined
-	}
-
-	function task_form_from_host(host: HTMLElement | undefined): HTMLFormElement | undefined {
-		if (host === undefined) return undefined
-
-		const found = host.closest('form')
-
-		return found instanceof HTMLFormElement ? found : undefined
-	}
-
-	function resolve_inline_task_form(anchor?: HTMLElement): HTMLFormElement | undefined {
-		const from_anchor = task_form_from_host(anchor)
-		if (from_anchor !== undefined) return from_anchor
-
-		const from_title = task_form_from_host(title_input_el)
-		if (from_title !== undefined) return from_title
-
-		const from_dialog = task_form_from_host(recurrence_dialog_element)
-		if (from_dialog !== undefined) return from_dialog
-
-		return form_element
-	}
-
-	function write_rr_enhance_grace_ms(duration_ms: number, anchor?: HTMLElement): void {
-		const el = resolve_inline_task_form(anchor)
-		if (el === undefined) return
-
-		el.setAttribute(ATTR_RR_ENH_GRACE_UNTIL, String(globalThis.performance.now() + duration_ms))
-	}
-
-	function is_rr_enhance_grace_active_on(submit_form: HTMLFormElement): boolean {
-		const raw = submit_form.getAttribute(ATTR_RR_ENH_GRACE_UNTIL)
-		if (raw === null) return false
-
-		const until = Number(raw)
-
-		return Number.isFinite(until) && globalThis.performance.now() < until
-	}
-
-	function is_live_open_dialog(host: HTMLDialogElement | undefined): boolean {
-		return Boolean(host?.isConnected && host.open)
-	}
-
-	function is_dialog_open(): boolean {
-		if (is_live_open_dialog(recurrence_dialog_element)) return true
-
-		return is_live_open_dialog(read_rr_dialog_from_dom())
-	}
-
-	function is_rr_dialog_null_focusout(focus_event: FocusEvent): boolean {
-		if (focus_event.relatedTarget !== null) return false
-		const { target } = focus_event
-		if (!(target instanceof Element)) return false
-
-		return target.closest(SELECTOR_DASH_RR_DIALOG) !== null
-	}
-
-	function get_related_node(focus_event: FocusEvent): Node | undefined {
-		const target = focus_event.relatedTarget
-
-		return target instanceof Node ? target : undefined
-	}
-
-	function should_skip_form_focusout(focus_event: FocusEvent): boolean {
-		const related = get_related_node(focus_event)
-		if (dash_task_form_shared.is_focus_still_inside_form(form_element, related)) return true
-		if (is_rr_dialog_null_focusout(focus_event)) return true
-		if (globalThis.performance.now() < rr_close_blur_grace_until_ms) return true
-		if (is_rr_dialog_session) return true
-
-		return false
-	}
-
-	async function next_animation_frame(): Promise<void> {
-		await new Promise<void>((resolve) => {
-			globalThis.requestAnimationFrame(() => {
-				resolve()
-			})
-		})
-	}
-
-	function open_recurrence_dialog(anchor?: HTMLElement): void {
-		write_rr_enhance_grace_ms(RR_OPEN_ENH_BLOCK_MS, anchor)
-		rrule_draft = form_rrule
-		recurrence_dialog_mount_key += 1
-		is_rr_dialog_session = true
-		recurrence_dialog_element?.showModal()
-	}
-
-	function close_rr_dialog_ui(anchor?: HTMLElement): void {
-		write_rr_enhance_grace_ms(RR_CLOSE_ENH_CANCEL_MS, anchor)
-		rr_close_blur_grace_until_ms = globalThis.performance.now() + rr_close_blur_grace_ms
-		recurrence_dialog_element?.close()
-	}
-
-	function resolve_title_focus_target(): HTMLInputElement | undefined {
-		if (title_input_el !== undefined) return title_input_el
-
-		const from_form = form_element?.querySelector(SELECTOR_INLINE_TITLE)
-
-		return from_form instanceof HTMLInputElement ? from_form : undefined
-	}
-
-	async function refocus_title_through_churn(): Promise<void> {
-		resolve_title_focus_target()?.focus()
-		await new Promise<void>((resolve) => {
-			globalThis.setTimeout(() => {
-				resolve_title_focus_target()?.focus()
-				resolve()
-			}, 0)
-		})
-		await new Promise<void>((resolve) => {
-			globalThis.setTimeout(() => {
-				resolve_title_focus_target()?.focus()
-				resolve()
-			}, RR_POST_MODAL_FOCUS_MS)
-		})
-	}
-
-	$effect(() => {
-		if (focus_request_id <= last_seen_focus_request_id) return
-
-		last_seen_focus_request_id = focus_request_id
+		state.last_seen_focus_request_id = focus_request_id
 
 		void (async () => {
 			await tick()
 			await tick()
-			await next_animation_frame()
-			const title_el = resolve_title_focus_target()
+			await new Promise<void>((resolve) => {
+				globalThis.requestAnimationFrame(() => {
+					resolve()
+				})
+			})
+			const title_element = state.title_input_el
 
-			if (title_el) {
-				title_el.focus()
-				title_el.setSelectionRange(title_el.value.length, title_el.value.length)
+			if (title_element) {
+				title_element.focus()
+				title_element.setSelectionRange(title_element.value.length, title_element.value.length)
 			}
 		})()
 	})
-
-	async function focus_title_after_rr_close(): Promise<void> {
-		await tick()
-		await next_animation_frame()
-		await next_animation_frame()
-		await refocus_title_through_churn()
-		await next_animation_frame()
-	}
-
-	async function end_rr_session_clear_enhance(): Promise<void> {
-		is_rr_dialog_session = false
-		rr_close_blur_grace_until_ms = 0
-		form_element?.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
-		await tick()
-		await next_animation_frame()
-	}
-
-	function submit_dirty_if_rr_idle(): void {
-		commit_pending_label_input()
-		clear_blur_discard_timer()
-
-		if (!is_form_saving && form_title.trim() !== '' && is_form_dirty()) {
-			is_blur_commit_pending = false
-			submit_reason = 'normal'
-			is_rr_post_close_submit = true
-			form_element?.requestSubmit()
-		}
-	}
-
-	async function handle_recurrence_dialog_close(): Promise<void> {
-		/* Dialog close uses pointerdown/up; drop stale deferred blur before refocus + submit. */
-		clear_blur_discard_timer()
-		is_blur_deferred_to_pointer_up = false
-		form_rrule = rrule_draft
-		write_rr_enhance_grace_ms(RR_CLOSE_ENH_CANCEL_MS)
-		rr_close_blur_grace_until_ms = globalThis.performance.now() + rr_close_blur_grace_ms
-		await focus_title_after_rr_close()
-		await end_rr_session_clear_enhance()
-		await tick()
-		await next_animation_frame()
-		submit_dirty_if_rr_idle()
-	}
-
-	function is_due_input_focused(): boolean {
-		return due_picker_input_el !== undefined && document.activeElement === due_picker_input_el
-	}
-
-	function is_blocking_interaction_active(): boolean {
-		return is_dialog_open() || is_form_saving || is_date_picker_open
-	}
-
-	function is_rr_blur_block_active(): boolean {
-		if (is_rr_dialog_session) return true
-		if (globalThis.performance.now() < rr_close_blur_grace_until_ms) return true
-
-		return false
-	}
-
-	function should_abort_blur_commit(): boolean {
-		if (is_rr_blur_block_active()) return true
-		if (form_element?.contains(document.activeElement)) return true
-		if (is_due_input_focused()) return true
-
-		return is_blocking_interaction_active()
-	}
-
-	function read_task_id_from_title_host(host: HTMLElement): string | undefined {
-		/* eslint-disable-next-line unicorn/prefer-dom-node-dataset -- `dataset` index typing is awkward; marker is fixed. */
-		const raw_id = (host.getAttribute('data-task-id') ?? '').trim()
-
-		return raw_id === '' ? undefined : raw_id
-	}
-
-	function title_host_from_related(related: HTMLElement): HTMLElement | undefined {
-		const host = related.closest('[data-dash-task-title]')
-		if (host === null) return undefined
-
-		return host instanceof HTMLElement ? host : undefined
-	}
-
-	function read_title_switch_task_id(related: EventTarget | null): string | undefined {
-		if (!(related instanceof HTMLElement)) return undefined
-
-		const host = title_host_from_related(related)
-		if (host === undefined) return undefined
-
-		return read_task_id_from_title_host(host)
-	}
-
-	function read_card_switch_task_id(related: EventTarget | null): string | undefined {
-		if (!(related instanceof HTMLElement)) return undefined
-
-		const card = related.closest('[data-dash-task-card]')
-		if (!(card instanceof HTMLElement)) return undefined
-
-		/* eslint-disable-next-line unicorn/prefer-dom-node-dataset -- same reason as title host */
-		const raw_id = (card.getAttribute('data-dash-task-card') ?? '').trim()
-
-		return raw_id === '' ? undefined : raw_id
-	}
-
-	function is_switching_to_other_task(related: EventTarget | null): boolean {
-		const title_id = read_title_switch_task_id(related)
-		if (title_id !== undefined && title_id !== task_item.id) return true
-
-		const card_id = read_card_switch_task_id(related)
-
-		return card_id !== undefined && card_id !== task_item.id
-	}
-
-	async function run_discard_empty_animated(): Promise<void> {
-		if (on_try_discard_empty === undefined) return
-		await on_try_discard_empty()
-	}
-
-	async function apply_empty_blur_outcome(): Promise<void> {
-		if (is_node_inside_add_task_region(document.activeElement)) return
-		if (is_arrow_nav_discard_active) return
-
-		await run_discard_empty_animated()
-	}
-
-	function apply_dirty_blur_submit(): void {
-		if (is_rr_blur_block_active()) return
-
-		commit_pending_label_input()
-		is_blur_commit_pending = true
-		submit_reason = 'normal'
-		form_element?.requestSubmit()
-	}
-
-	async function commit_blur_when_title_missing(): Promise<void> {
-		if (!is_never_titled_row()) {
-			revert_to_task_item()
-
-			return
-		}
-
-		await apply_empty_blur_outcome()
-	}
-
-	async function run_deferred_blur_commit(): Promise<void> {
-		if (should_abort_blur_commit()) return
-
-		if (!form_title.trim()) {
-			await commit_blur_when_title_missing()
-
-			return
-		}
-
-		if (is_form_dirty()) {
-			apply_dirty_blur_submit()
-
-			return
-		}
-
-		if (!is_navigating_away) on_escape()
-	}
-
-	function handle_form_focusout(focus_event: FocusEvent): void {
-		if (should_skip_form_focusout(focus_event)) return
-
-		clear_blur_discard_timer()
-
-		// Delay until pointerup so the row does not vanish on mousedown;
-		// the click event will complete normally before the editor closes.
-		if (is_pointer_held) {
-			is_blur_deferred_to_pointer_up = true
-
-			return
-		}
-
-		const delay_ms = is_switching_to_other_task(focus_event.relatedTarget)
-			? 0
-			: BLUR_COMMIT_DELAY_MS
-
-		blur_discard_timer = globalThis.setTimeout(() => {
-			blur_discard_timer = undefined
-			void run_deferred_blur_commit()
-		}, delay_ms)
-	}
-
-	function handle_document_pointerdown(): void {
-		is_pointer_held = true
-	}
-
-	async function handle_document_pointerup(): Promise<void> {
-		is_pointer_held = false
-
-		if (!is_blur_deferred_to_pointer_up) return
-
-		is_blur_deferred_to_pointer_up = false
-		await new Promise((resolve) => {
-			globalThis.setTimeout(resolve, POINTER_UP_SETTLE_MS)
-		})
-		await run_deferred_blur_commit()
-	}
-
-	function handle_document_pointercancel(): void {
-		is_pointer_held = false
-		is_blur_deferred_to_pointer_up = false
-	}
-
-	function is_escape_suppressed_by_modal(): boolean {
-		/* Blur still uses `is_rr_dialog_session`; Escape must work as soon as the dialog is gone
-		 * (post-close focus runs async and would otherwise swallow Escape until session ends). */
-		return is_dialog_open()
-	}
-
-	function should_discard_on_escape(): boolean {
-		return !form_title.trim() && is_never_titled_row()
-	}
-
-	function finalize_standard_escape(): void {
-		revert_to_task_item()
-		on_escape()
-	}
-
-	function apply_escape_key_outcome(): void {
-		close_dialogs()
-
-		if (should_discard_on_escape()) {
-			void on_try_discard_empty?.()
-
-			return
-		}
-
-		finalize_standard_escape()
-	}
-
-	function handle_document_keydown(key_event: KeyboardEvent): void {
-		if (key_event.key !== 'Escape' || key_event.isComposing) return
-		if (is_escape_suppressed_by_modal()) return
-
-		key_event.preventDefault()
-		apply_escape_key_outcome()
-	}
-
-	function try_submit_form(): void {
-		if (is_rr_blur_block_active()) return
-		if (is_form_saving || form_title.trim() === '') return
-
-		commit_pending_label_input()
-		clear_blur_discard_timer()
-		is_blur_commit_pending = false
-		submit_reason = 'normal'
-
-		form_element?.requestSubmit()
-	}
-
-	function is_plain_enter_key(key_event: KeyboardEvent): boolean {
-		return key_event.key === 'Enter' && !key_event.shiftKey && !key_event.isComposing
-	}
-
-	function handle_arrow_without_title(direction: 'up' | 'down'): void {
-		if (!is_never_titled_row()) revert_to_task_item()
-
-		is_navigating_away = true
-		on_navigate_arrow?.(direction)
-
-		if (is_never_titled_row()) {
-			is_arrow_nav_discard_active = true
-			void on_try_discard_empty?.()
-		}
-	}
-
-	function handle_arrow_with_title(direction: 'up' | 'down'): void {
-		if (is_form_dirty()) try_submit_form()
-
-		is_navigating_away = true
-		on_navigate_arrow?.(direction)
-	}
-
-	function handle_arrow_navigation(key_event: KeyboardEvent): void {
-		if (key_event.isComposing) return
-
-		const direction = dash_inline_editor_keyboard.read_vertical_arrow_direction(key_event)
-		if (direction === undefined) return
-
-		key_event.preventDefault()
-
-		if (!form_title.trim()) {
-			handle_arrow_without_title(direction)
-
-			return
-		}
-
-		handle_arrow_with_title(direction)
-	}
-
-	function handle_title_enter_confirm(key_event: KeyboardEvent): void {
-		key_event.preventDefault()
-		if (is_rr_blur_block_active()) return
-		if (is_form_saving) return
-		if (!form_title.trim()) return
-
-		clear_blur_discard_timer()
-		is_blur_commit_pending = false
-		submit_reason = 'title_enter_new'
-		form_element?.requestSubmit()
-	}
-
-	function handle_title_keydown(key_event: KeyboardEvent): void {
-		if (dash_inline_editor_keyboard.read_vertical_arrow_direction(key_event) !== undefined) {
-			handle_arrow_navigation(key_event)
-
-			return
-		}
-
-		if (!is_plain_enter_key(key_event)) return
-
-		handle_title_enter_confirm(key_event)
-	}
-
-	function handle_detail_keydown(key_event: KeyboardEvent): void {
-		if (key_event.key === 'Enter' && !key_event.shiftKey && !key_event.isComposing) {
-			key_event.preventDefault()
-			try_submit_form()
-		}
-	}
-
-	function open_due_picker(): void {
-		const el = due_picker_input_el
-		if (!el) return
-
-		is_date_picker_open = true
-
-		if (typeof el.showPicker === 'function') {
-			el.showPicker()
-		} else {
-			el.click()
-		}
-	}
-
-	function is_title_enter_chain(reason: 'normal' | 'title_enter_new'): boolean {
-		return reason === 'title_enter_new' && on_title_enter_saved !== undefined
-	}
-
-	function is_blur_commit_exit(
-		reason: 'normal' | 'title_enter_new',
-		is_saved_via_blur_commit: boolean,
-	): boolean {
-		return reason === 'normal' && is_saved_via_blur_commit && on_blur_commit_saved !== undefined
-	}
-
-	async function run_after_successful_update(
-		reason: 'normal' | 'title_enter_new',
-		is_saved_via_blur_commit: boolean,
-	): Promise<void> {
-		if (is_title_enter_chain(reason)) {
-			await on_title_enter_saved?.()
-
-			return
-		}
-
-		if (is_blur_commit_exit(reason, is_saved_via_blur_commit)) {
-			await on_blur_commit_saved?.()
-
-			return
-		}
-
-		await on_saved()
-	}
-
-	function reset_blur_defer_flags(): void {
-		clear_blur_discard_timer()
-		is_blur_deferred_to_pointer_up = false
-	}
-
-	async function finalize_success_then_refocus(
-		reason: 'normal' | 'title_enter_new',
-		is_saved_via_blur_commit: boolean,
-		update: (options?: { reset?: boolean }) => Promise<void>,
-	): Promise<void> {
-		close_dialogs()
-		edit_error = undefined
-		is_blur_commit_pending = false
-		reset_blur_defer_flags()
-		await update({ reset: false })
-		reset_blur_defer_flags()
-
-		const did_navigate_away = is_navigating_away
-
-		/* Same task id skips the seed $effect; align with load data so normalized fields (e.g. rrule) are not left dirty. */
-		await tick()
-		sync_form_from_task_item()
-		await run_after_successful_update(reason, is_saved_via_blur_commit)
-		reset_blur_defer_flags()
-
-		if (!is_blur_commit_exit(reason, is_saved_via_blur_commit) && !did_navigate_away) {
-			await tick()
-			await next_animation_frame()
-			await next_animation_frame()
-			await refocus_title_through_churn()
-		}
-	}
-
-	async function finalize_update_action(
-		result: ActionResult,
-		update: (options?: { reset?: boolean }) => Promise<void>,
-	): Promise<void> {
-		is_form_saving = false
-		const reason = submit_reason
-
-		submit_reason = 'normal'
-
-		if (result.type === 'success') {
-			const is_saved_via_blur_commit = is_blur_commit_pending
-
-			await finalize_success_then_refocus(reason, is_saved_via_blur_commit, update)
-
-			return
-		}
-
-		is_blur_commit_pending = false
-		edit_error = dash_task_form_shared.read_action_error(result)
-		await update({ reset: false })
-	}
-
-	async function handle_update_enhance_result(input: {
-		result: ActionResult
-		update: (options?: { reset?: boolean }) => Promise<void>
-	}): Promise<void> {
-		await finalize_update_action(input.result, input.update)
-	}
 </script>
 
-<svelte:window onkeydown={handle_document_keydown} />
+<svelte:window
+	onkeydown={(key_event: KeyboardEvent) => {
+		state.handle_document_keydown(key_event)
+	}}
+/>
 <svelte:document
-	onpointerdown={handle_document_pointerdown}
-	onpointerup={handle_document_pointerup}
-	onpointercancel={handle_document_pointercancel}
+	onpointerdown={() => {
+		state.handle_document_pointerdown()
+	}}
+	onpointerup={async () => {
+		await state.handle_document_pointerup()
+	}}
+	onpointercancel={() => {
+		state.handle_document_pointercancel()
+	}}
 />
 
 <div
@@ -853,43 +102,18 @@
 >
 	<div class="-m-1 overflow-hidden p-1">
 		<form
-			bind:this={form_element}
+			bind:this={state.form_element}
 			method="POST"
 			action="?/update_task"
-			use:enhance={(submission) => {
-				if (is_rr_enhance_grace_active_on(submission.formElement)) {
-					submission.cancel()
-
-					return handle_update_enhance_result
-				}
-
-				if (is_rr_blur_block_active()) {
-					submission.cancel()
-
-					return handle_update_enhance_result
-				}
-
-				const is_dialog_submit_exempt = is_rr_post_close_submit
-
-				if (is_dialog_open() && !is_dialog_submit_exempt) {
-					submission.cancel()
-
-					return handle_update_enhance_result
-				}
-
-				is_rr_post_close_submit = false
-				submission.formElement.removeAttribute(ATTR_RR_ENH_GRACE_UNTIL)
-				clear_blur_discard_timer()
-				is_form_saving = true
-
-				return handle_update_enhance_result
-			}}
+			use:enhance={state.get_enhance_callback()}
 			class="relative min-w-0 flex-1 space-y-1.5"
-			onfocusout={handle_form_focusout}
+			onfocusout={(focus_event: FocusEvent) => {
+				state.handle_form_focusout(focus_event)
+			}}
 		>
 			<input type="hidden" name="task_id" value={task_item.id} />
 
-			{#if is_form_saving}
+			{#if state.is_form_saving}
 				<div
 					class="absolute inset-e-0 top-0 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
 				>
@@ -899,192 +123,123 @@
 			{/if}
 
 			<input
-				bind:this={title_input_el}
+				bind:this={state.title_input_el}
 				type="text"
 				name="title"
 				data-testid="dash-inline-title-input"
-				bind:value={form_title}
+				bind:value={state.form_title}
 				placeholder={m.dash_create_title_placeholder()}
 				class={input_class}
-				onkeydown={handle_title_keydown}
+				onkeydown={(key_event: KeyboardEvent) => {
+					state.handle_title_keydown(key_event)
+				}}
 			/>
 
 			<textarea
-				bind:this={detail_textarea_el}
+				bind:this={state.detail_textarea_el}
 				name="detail"
 				data-testid="dash-inline-detail-input"
-				bind:value={form_detail}
+				bind:value={state.form_detail}
 				placeholder={m.dash_create_detail_placeholder()}
 				rows="1"
 				class="{input_class} min-h-9 resize-none overflow-hidden"
-				onkeydown={handle_detail_keydown}
+				onkeydown={(key_event: KeyboardEvent) => {
+					state.handle_detail_keydown(key_event)
+				}}
 				oninput={() => {
-					dash_task_form_shared.sync_textarea_height(detail_textarea_el)
+					dash_task_form_shared.sync_textarea_height(state.detail_textarea_el)
 				}}
 			></textarea>
 
 			<div class="space-y-1.5">
-				{#each form_selected_labels as hidden_label (hidden_label)}
-					<input type="hidden" name="labels" value={hidden_label} />
-				{/each}
-				{#if data.labels.length > 0 || pending_new_label_names.length > 0}
-					<div class="flex flex-wrap gap-1.5">
-						{#each data.labels as label_row (label_row.id)}
-							<button
-								type="button"
-								onclick={() => {
-									toggle_label_name(label_row.name)
-								}}
-								class={dash_display.label_chip_filter_class(
-									label_row.name,
-									form_selected_labels.includes(label_row.name),
-								)}
-							>
-								{label_row.name}
-							</button>
-						{/each}
-						{#each pending_new_label_names as new_label (new_label)}
-							<span
-								class="{dash_display.label_chip_filter_class(
-									new_label,
-									true,
-								)} inline-flex items-center gap-1"
-							>
-								{new_label}
-								<button
-									type="button"
-									aria-label="Remove label"
-									onclick={() => {
-										form_selected_labels = form_selected_labels.filter((name) => name !== new_label)
-									}}
-									class="leading-none">×</button
-								>
-							</span>
-						{/each}
-					</div>
-				{/if}
-				<div class="relative">
-					<input
-						type="text"
-						data-testid="dash-inline-label-input"
-						bind:value={form_label_input}
-						onkeydown={handle_label_keydown}
-						onfocus={() => (is_form_label_focused = true)}
-						onblur={() => {
-							setTimeout(() => {
-								is_form_label_focused = false
-							}, LABEL_BLUR_DELAY_MS)
-						}}
-						placeholder={m.dash_create_label_placeholder()}
-						class={input_class}
-					/>
-					{#if is_form_label_focused && label_suggestions.length > 0}
-						<div
-							class="absolute top-full z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800"
-						>
-							{#each label_suggestions as suggestion (suggestion.id)}
-								<button
-									type="button"
-									class="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700"
-									onclick={() => {
-										add_label(suggestion.name)
-									}}
-								>
-									{suggestion.name}
-								</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
+				<DashTaskLabelPicker
+					all_labels={data.labels}
+					selected_labels={state.form_selected_labels}
+					bind:label_input={state.form_label_input}
+					{input_class}
+					input_testid="dash-inline-label-input"
+					on_toggle={(name: string) => {
+						state.toggle_label_name(name)
+					}}
+					on_add={(name: string) => {
+						state.add_label(name)
+					}}
+					on_remove_pending={(name: string) => {
+						state.form_selected_labels = state.form_selected_labels.filter(
+							(label_name) => label_name !== name,
+						)
+					}}
+					on_keydown={(key_event: KeyboardEvent) => {
+						state.handle_label_keydown(key_event)
+					}}
+				/>
 			</div>
 
 			<input
-				bind:this={due_picker_input_el}
+				bind:this={state.due_picker_input_el}
 				type="date"
 				name="due_date"
-				bind:value={form_due_date}
+				bind:value={state.form_due_date}
 				class="sr-only"
 				tabindex={-1}
 				aria-hidden="true"
 				onchange={() => {
-					is_date_picker_open = false
-					title_input_el?.focus()
+					state.is_date_picker_open = false
+					state.title_input_el?.focus()
 				}}
 			/>
-			<input type="hidden" name="recurrence_rule" value={form_rrule} />
+			<input type="hidden" name="recurrence_rule" value={state.form_rrule} />
 
 			<div class="flex flex-wrap items-center gap-2">
-				{#if form_due_date}
-					<div class="flex flex-wrap items-center gap-1.5">
-						<button
-							type="button"
-							onclick={open_due_picker}
-							class="flex h-9 w-9 shrink-0 items-center justify-center text-gray-400 transition-colors hover:bg-gray-100 hover:text-blue-600 dark:hover:bg-gray-700 dark:hover:text-blue-400"
-							aria-label={m.dash_create_due_pick_aria()}
-						>
-							<svg
-								class="h-5 w-5"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								aria-hidden="true"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="1.5"
-									d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-								></path>
-							</svg>
-						</button>
-						<span class="text-sm text-gray-700 dark:text-gray-200">{due_display_text}</span>
-						<button
-							type="button"
-							onclick={() => {
-								form_due_date = ''
-							}}
-							class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-700 dark:hover:text-red-400"
-							aria-label={m.dash_create_due_clear()}
-						>
-							<svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-								<path
-									fill-rule="evenodd"
-									d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-									clip-rule="evenodd"
-								></path>
-							</svg>
-						</button>
-					</div>
-				{:else}
+				<button
+					type="button"
+					onclick={() => {
+						state.open_due_picker()
+					}}
+					class="flex h-9 w-9 shrink-0 items-center justify-center text-gray-400 transition-colors hover:bg-gray-100 hover:text-blue-600 dark:hover:bg-gray-700 dark:hover:text-blue-400"
+					aria-label={m.dash_create_due_pick_aria()}
+				>
+					<svg
+						class="h-5 w-5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						aria-hidden="true"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+							d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+						></path>
+					</svg>
+				</button>
+				{#if state.form_due_date}
+					<span class="text-sm text-gray-700 dark:text-gray-200">{state.due_display_text}</span>
 					<button
 						type="button"
-						onclick={open_due_picker}
-						class="flex h-9 w-9 shrink-0 items-center justify-center text-gray-400 transition-colors hover:bg-gray-100 hover:text-blue-600 dark:hover:bg-gray-700 dark:hover:text-blue-400"
-						aria-label={m.dash_create_due_pick_aria()}
+						onclick={() => {
+							state.form_due_date = ''
+						}}
+						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-700 dark:hover:text-red-400"
+						aria-label={m.dash_create_due_clear()}
 					>
-						<svg
-							class="h-5 w-5"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							aria-hidden="true"
-						>
+						<svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="1.5"
-								d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+								fill-rule="evenodd"
+								d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+								clip-rule="evenodd"
 							></path>
 						</svg>
 					</button>
 				{/if}
 
-				{#if form_rrule}
+				{#if state.form_rrule}
 					<button
 						type="button"
 						data-testid="dash-inline-recurrence-button"
 						onclick={(mouse_event) => {
-							open_recurrence_dialog(
+							state.open_recurrence_dialog(
 								mouse_event.currentTarget instanceof HTMLElement
 									? mouse_event.currentTarget
 									: undefined,
@@ -1092,13 +247,13 @@
 						}}
 						class="rounded-lg border border-gray-200 px-2 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700/80"
 					>
-						{recurrence_edit_button_text}
+						{state.recurrence_edit_button_text}
 					</button>
 				{:else}
 					<button
 						type="button"
 						onclick={(mouse_event) => {
-							open_recurrence_dialog(
+							state.open_recurrence_dialog(
 								mouse_event.currentTarget instanceof HTMLElement
 									? mouse_event.currentTarget
 									: undefined,
@@ -1113,17 +268,19 @@
 			</div>
 
 			<dialog
-				bind:this={recurrence_dialog_element}
+				bind:this={state.recurrence_dialog_element}
 				data-testid="dash-recurrence-dialog"
 				class={DIALOG_RECURRENCE_CLASS}
-				onclose={handle_recurrence_dialog_close}
+				onclose={async () => {
+					await state.handle_recurrence_dialog_close()
+				}}
 			>
 				<h2 class="mb-3 text-sm font-semibold text-gray-900 dark:text-white">
 					{m.dash_create_recurrence_dialog_title()}
 				</h2>
-				{#key recurrence_dialog_mount_key}
-					{#if recurrence_dialog_mount_key > 0}
-						<RecurrenceInput bind:value={rrule_draft} />
+				{#key state.recurrence_dialog_mount_key}
+					{#if state.recurrence_dialog_mount_key > 0}
+						<RecurrenceInput bind:value={state.rrule_draft} />
 					{/if}
 				{/key}
 				<div class="mt-4 flex justify-end">
@@ -1136,7 +293,7 @@
 						onclick={(mouse_event) => {
 							mouse_event.preventDefault()
 							mouse_event.stopPropagation()
-							close_rr_dialog_ui(
+							state.close_rr_dialog_ui(
 								mouse_event.currentTarget instanceof HTMLElement
 									? mouse_event.currentTarget
 									: undefined,
@@ -1148,8 +305,8 @@
 				</div>
 			</dialog>
 
-			{#if edit_error}
-				<p class="text-sm text-red-500">{edit_error}</p>
+			{#if state.edit_error}
+				<p class="text-sm text-red-500">{state.edit_error}</p>
 			{/if}
 			{#if form?.error}
 				<p class="text-sm text-red-500">{form.error}</p>

--- a/src/lib/components/dash/DashTaskInlineEditor.svelte
+++ b/src/lib/components/dash/DashTaskInlineEditor.svelte
@@ -56,6 +56,7 @@
 		},
 	)
 
+	// Wait for Svelte DOM updates (tick x2) and any slide transition to settle (RAF) before focusing.
 	$effect(() => {
 		if (focus_request_id <= state.last_seen_focus_request_id) return
 

--- a/src/lib/components/dash/DashTaskLabelPicker.svelte
+++ b/src/lib/components/dash/DashTaskLabelPicker.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	/* eslint-disable prefer-const -- $bindable() props must use let in a single $props() destructuring */
+	import { dash_display } from '$lib/dash-display'
+	import { m } from '$lib/paraglide/messages'
+	import {
+		dash_task_form_shared,
+		LABEL_BLUR_DELAY_MS,
+		type LabelItem,
+	} from './dash-task-form-shared'
+
+	interface Props {
+		all_labels: ReadonlyArray<LabelItem>
+		selected_labels: ReadonlyArray<string>
+		label_input?: string
+		input_class: string
+		on_toggle: (name: string) => void
+		on_add: (name: string) => void
+		on_remove_pending: (name: string) => void
+		on_keydown?: (event: KeyboardEvent) => void
+		input_testid?: string
+	}
+
+	let {
+		all_labels,
+		selected_labels,
+		label_input = $bindable(''),
+		input_class,
+		on_toggle,
+		on_add,
+		on_remove_pending,
+		on_keydown,
+		input_testid,
+	}: Props = $props()
+
+	const pending_new_label_names = $derived(
+		dash_task_form_shared.compute_pending_new_labels(selected_labels, all_labels),
+	)
+	const label_suggestions = $derived(
+		dash_task_form_shared.compute_label_suggestions(label_input, all_labels, selected_labels),
+	)
+
+	let is_label_focused = $state(false)
+</script>
+
+{#each selected_labels as hidden_label (hidden_label)}
+	<input type="hidden" name="labels" value={hidden_label} />
+{/each}
+{#if all_labels.length > 0 || pending_new_label_names.length > 0}
+	<div class="flex flex-wrap gap-1.5">
+		{#each all_labels as label_row (label_row.id)}
+			<button
+				type="button"
+				onclick={() => {
+					on_toggle(label_row.name)
+				}}
+				class={dash_display.label_chip_filter_class(
+					label_row.name,
+					selected_labels.includes(label_row.name),
+				)}
+			>
+				{label_row.name}
+			</button>
+		{/each}
+		{#each pending_new_label_names as new_label (new_label)}
+			<span
+				class="{dash_display.label_chip_filter_class(
+					new_label,
+					true,
+				)} inline-flex items-center gap-1"
+			>
+				{new_label}
+				<button
+					type="button"
+					aria-label="Remove label"
+					onclick={() => {
+						on_remove_pending(new_label)
+					}}
+					class="leading-none">×</button
+				>
+			</span>
+		{/each}
+	</div>
+{/if}
+<div class="relative">
+	<input
+		type="text"
+		data-testid={input_testid}
+		bind:value={label_input}
+		onkeydown={on_keydown}
+		onfocus={() => {
+			is_label_focused = true
+		}}
+		onblur={() => {
+			setTimeout(() => {
+				is_label_focused = false
+			}, LABEL_BLUR_DELAY_MS)
+		}}
+		placeholder={m.dash_create_label_placeholder()}
+		class={input_class}
+	/>
+	{#if is_label_focused && label_suggestions.length > 0}
+		<div
+			class="absolute top-full z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800"
+		>
+			{#each label_suggestions as suggestion (suggestion.id)}
+				<button
+					type="button"
+					class="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700"
+					onclick={() => {
+						on_add(suggestion.name)
+					}}
+				>
+					{suggestion.name}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/dash/DashTaskLabelPicker.svelte
+++ b/src/lib/components/dash/DashTaskLabelPicker.svelte
@@ -71,7 +71,7 @@
 				{new_label}
 				<button
 					type="button"
-					aria-label="Remove label"
+					aria-label={m.dash_label_remove_aria()}
 					onclick={() => {
 						on_remove_pending(new_label)
 					}}

--- a/src/lib/components/dash/dash-inline-editor-helpers.ts
+++ b/src/lib/components/dash/dash-inline-editor-helpers.ts
@@ -1,0 +1,131 @@
+/* eslint-disable unicorn/prefer-dom-node-dataset -- dataset index typing is awkward; markers are fixed */
+const ATTR_RR_ENH_GRACE_UNTIL = 'data-dash-rr-enhance-grace-until'
+const SELECTOR_DASH_RR_DIALOG = '[data-testid="dash-recurrence-dialog"]'
+const SELECTOR_INLINE_TITLE = '[data-testid="dash-inline-title-input"]'
+const RR_POST_MODAL_FOCUS_MS = 100
+
+function is_node_inside_add_task_region(node: Node | null): boolean {
+	return node instanceof HTMLElement && Boolean(node.closest('[data-dash-add-task-region]'))
+}
+
+async function next_animation_frame(): Promise<void> {
+	await new Promise<void>((resolve) => {
+		globalThis.requestAnimationFrame(() => {
+			resolve()
+		})
+	})
+}
+
+function is_live_open_dialog(host: HTMLDialogElement | undefined): boolean {
+	return Boolean(host?.isConnected && host.open)
+}
+
+function task_form_from_host(host: HTMLElement | undefined): HTMLFormElement | undefined {
+	if (host === undefined) return undefined
+
+	const found = host.closest('form')
+
+	return found instanceof HTMLFormElement ? found : undefined
+}
+
+function read_rr_dialog_from_dom(
+	form_element: HTMLFormElement | undefined,
+): HTMLDialogElement | undefined {
+	const host = form_element?.querySelector(SELECTOR_DASH_RR_DIALOG)
+
+	return host instanceof HTMLDialogElement ? host : undefined
+}
+
+function write_rr_enhance_grace_ms(
+	element: HTMLFormElement | undefined,
+	duration_ms: number,
+): void {
+	const expires_at = String(globalThis.performance.now() + duration_ms)
+
+	element?.setAttribute(ATTR_RR_ENH_GRACE_UNTIL, expires_at)
+}
+
+function is_rr_enhance_grace_active_on(submit_form: HTMLFormElement): boolean {
+	const raw = submit_form.getAttribute(ATTR_RR_ENH_GRACE_UNTIL)
+	if (raw === null) return false
+
+	const until = Number(raw)
+
+	return Number.isFinite(until) && globalThis.performance.now() < until
+}
+
+function is_rr_dialog_null_focusout(focus_event: FocusEvent): boolean {
+	if (focus_event.relatedTarget !== null) return false
+
+	const { target } = focus_event
+	if (!(target instanceof Element)) return false
+
+	return target.closest(SELECTOR_DASH_RR_DIALOG) !== null
+}
+
+function resolve_title_focus_target(
+	title_input_element: HTMLInputElement | undefined,
+	form_element: HTMLFormElement | undefined,
+): HTMLInputElement | undefined {
+	if (title_input_element !== undefined) return title_input_element
+
+	const from_form = form_element?.querySelector(SELECTOR_INLINE_TITLE)
+
+	return from_form instanceof HTMLInputElement ? from_form : undefined
+}
+
+function read_task_id_from_title_host(host: HTMLElement): string | undefined {
+	const raw_id = (host.getAttribute('data-task-id') ?? '').trim()
+
+	return raw_id === '' ? undefined : raw_id
+}
+
+function title_host_from_related(related: HTMLElement): HTMLElement | undefined {
+	const host = related.closest('[data-dash-task-title]')
+
+	return host instanceof HTMLElement ? host : undefined
+}
+
+function read_title_switch_task_id(related: EventTarget | null): string | undefined {
+	if (!(related instanceof HTMLElement)) return undefined
+
+	const host = title_host_from_related(related)
+	if (host === undefined) return undefined
+
+	return read_task_id_from_title_host(host)
+}
+
+function read_card_switch_task_id(related: EventTarget | null): string | undefined {
+	if (!(related instanceof HTMLElement)) return undefined
+
+	const card = related.closest('[data-dash-task-card]')
+	if (!(card instanceof HTMLElement)) return undefined
+
+	const raw_id = (card.getAttribute('data-dash-task-card') ?? '').trim()
+
+	return raw_id === '' ? undefined : raw_id
+}
+
+function is_switching_to_other_task(related: EventTarget | null, task_id: string): boolean {
+	const title_id = read_title_switch_task_id(related)
+	if (title_id !== undefined && title_id !== task_id) return true
+
+	const card_id = read_card_switch_task_id(related)
+
+	return card_id !== undefined && card_id !== task_id
+}
+
+const dash_inline_editor_helpers = {
+	is_node_inside_add_task_region,
+	next_animation_frame,
+	is_live_open_dialog,
+	task_form_from_host,
+	read_rr_dialog_from_dom,
+	write_rr_enhance_grace_ms,
+	is_rr_enhance_grace_active_on,
+	is_rr_dialog_null_focusout,
+	resolve_title_focus_target,
+	is_switching_to_other_task,
+}
+
+export { ATTR_RR_ENH_GRACE_UNTIL, RR_POST_MODAL_FOCUS_MS, dash_inline_editor_helpers }

--- a/src/lib/components/dash/dash-task-form-shared.spec.ts
+++ b/src/lib/components/dash/dash-task-form-shared.spec.ts
@@ -1,9 +1,11 @@
+/* eslint-disable unicorn/no-null -- TaskFieldSnapshot mirrors nullable DB fields */
 import type { ActionResult } from '@sveltejs/kit'
 import { describe, expect, it } from 'vitest'
 import { dash_task_form_shared, RRULE_BUTTON_DISPLAY_MAX_CHARS } from './dash-task-form-shared'
 
 const ERROR_MESSAGE = 'Something went wrong'
 const EXISTING_LABEL_NAME = 'existing-label'
+const RRULE_WEEKLY = 'FREQ=WEEKLY'
 
 describe('read_action_error', () => {
 	it('returns default message for non-failure result', () => {
@@ -41,7 +43,7 @@ describe('read_action_error', () => {
 
 describe('truncate_rule_for_button', () => {
 	it('returns the original string when within the limit', () => {
-		const short = 'FREQ=WEEKLY'
+		const short = RRULE_WEEKLY
 
 		expect(dash_task_form_shared.truncate_rule_for_button(short)).toBe(short)
 	})
@@ -144,5 +146,130 @@ describe('compute_label_suggestions', () => {
 		const result = dash_task_form_shared.compute_label_suggestions('WORK', labels, [])
 
 		expect(result.map((label) => label.name)).toEqual(['work'])
+	})
+})
+
+describe('apply_add_label', () => {
+	it('appends the trimmed name when not already present', () => {
+		expect(dash_task_form_shared.apply_add_label(['a'], 'b')).toEqual(['a', 'b'])
+	})
+
+	it('trims the name before adding', () => {
+		expect(dash_task_form_shared.apply_add_label([], '  hello  ')).toEqual(['hello'])
+	})
+
+	it('returns the same array when the trimmed name already exists', () => {
+		const original = ['a']
+		const result = dash_task_form_shared.apply_add_label(original, 'a')
+
+		expect(result).toBe(original)
+	})
+
+	it('returns the same array for an empty string', () => {
+		const original = ['a']
+		const result = dash_task_form_shared.apply_add_label(original, '')
+
+		expect(result).toBe(original)
+	})
+
+	it('returns the same array for a whitespace-only string', () => {
+		const original = ['a']
+		const result = dash_task_form_shared.apply_add_label(original, '   ')
+
+		expect(result).toBe(original)
+	})
+})
+
+describe('apply_toggle_label', () => {
+	it('adds the name when not present', () => {
+		expect(dash_task_form_shared.apply_toggle_label(['a'], 'b')).toEqual(['a', 'b'])
+	})
+
+	it('removes the name when already present', () => {
+		expect(dash_task_form_shared.apply_toggle_label(['a', 'b'], 'a')).toEqual(['b'])
+	})
+})
+
+const TASK_DUE_DATE = '2026-01-01'
+const TASK_RRULE = 'FREQ=DAILY'
+
+const TASK_BASE = {
+	title: 'hello',
+	detail: 'details',
+	task_labels: [{ label: { name: 'work' } }],
+	due_date: TASK_DUE_DATE,
+	recurrence_rule: TASK_RRULE,
+} as const
+
+const FORM_MATCHING = {
+	title: 'hello',
+	detail: 'details',
+	selected_labels: ['work'],
+	due_date: TASK_DUE_DATE,
+	rrule: TASK_RRULE,
+} as const
+
+describe('is_inline_form_dirty / matching and text fields', () => {
+	it('returns false when all fields match the task', () => {
+		expect(dash_task_form_shared.is_inline_form_dirty(FORM_MATCHING, TASK_BASE)).toBe(false)
+	})
+
+	it('ignores leading/trailing whitespace in title and detail', () => {
+		const form = { ...FORM_MATCHING, title: '  hello  ', detail: '  details  ' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(false)
+	})
+
+	it('returns true when title differs', () => {
+		const form = { ...FORM_MATCHING, title: 'changed' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(true)
+	})
+
+	it('returns true when detail differs', () => {
+		const form = { ...FORM_MATCHING, detail: 'other' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(true)
+	})
+
+	it('treats null task detail as empty string', () => {
+		const task = { ...TASK_BASE, detail: null }
+		const form = { ...FORM_MATCHING, detail: '' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, task)).toBe(false)
+	})
+})
+
+describe('is_inline_form_dirty / labels and schedule', () => {
+	it('returns true when label set differs', () => {
+		const form = { ...FORM_MATCHING, selected_labels: ['personal'] }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(true)
+	})
+
+	it('returns true when due_date differs', () => {
+		const form = { ...FORM_MATCHING, due_date: '2026-06-01' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(true)
+	})
+
+	it('treats null task due_date as empty string', () => {
+		const task = { ...TASK_BASE, due_date: null }
+		const form = { ...FORM_MATCHING, due_date: '' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, task)).toBe(false)
+	})
+
+	it('returns true when rrule differs', () => {
+		const form = { ...FORM_MATCHING, rrule: RRULE_WEEKLY }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, TASK_BASE)).toBe(true)
+	})
+
+	it('treats null task recurrence_rule as empty string', () => {
+		const task = { ...TASK_BASE, recurrence_rule: null }
+		const form = { ...FORM_MATCHING, rrule: '' }
+
+		expect(dash_task_form_shared.is_inline_form_dirty(form, task)).toBe(false)
 	})
 })

--- a/src/lib/components/dash/dash-task-form-shared.ts
+++ b/src/lib/components/dash/dash-task-form-shared.ts
@@ -16,6 +16,22 @@ interface LabelItem {
 	name: string
 }
 
+interface InlineFormValues {
+	title: string
+	detail: string
+	selected_labels: ReadonlyArray<string>
+	due_date: string
+	rrule: string
+}
+
+interface TaskFieldSnapshot {
+	title: string
+	detail: string | null
+	task_labels: ReadonlyArray<{ label: { name: string } }>
+	due_date: string | null
+	recurrence_rule: string | null
+}
+
 function is_plain_object(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === 'object'
 }
@@ -80,6 +96,47 @@ function compute_pending_new_labels(
 	return selected.filter((name) => !existing.some((label) => label.name === name))
 }
 
+function apply_add_label(labels: ReadonlyArray<string>, name: string): Array<string> {
+	const trimmed = name.trim()
+
+	if (!trimmed || labels.includes(trimmed)) return labels as Array<string>
+
+	return [...labels, trimmed]
+}
+
+function apply_toggle_label(labels: ReadonlyArray<string>, name: string): Array<string> {
+	return labels.includes(name)
+		? labels.filter((label_name) => label_name !== name)
+		: [...labels, name]
+}
+
+function sorted_label_names(labels: ReadonlyArray<string>): Array<string> {
+	return [...labels].toSorted((left, right) => left.localeCompare(right))
+}
+
+function is_text_dirty(form: InlineFormValues, task: TaskFieldSnapshot): boolean {
+	return (
+		form.title.trim() !== task.title.trim() || form.detail.trim() !== (task.detail ?? '').trim()
+	)
+}
+
+function is_labels_dirty(form: InlineFormValues, task: TaskFieldSnapshot): boolean {
+	const task_label_names = task.task_labels.map((row) => row.label.name)
+
+	return (
+		sorted_label_names(form.selected_labels).join('\0') !==
+		sorted_label_names(task_label_names).join('\0')
+	)
+}
+
+function is_schedule_dirty(form: InlineFormValues, task: TaskFieldSnapshot): boolean {
+	return form.due_date !== (task.due_date ?? '') || form.rrule !== (task.recurrence_rule ?? '')
+}
+
+function is_inline_form_dirty(form: InlineFormValues, task: TaskFieldSnapshot): boolean {
+	return is_text_dirty(form, task) || is_labels_dirty(form, task) || is_schedule_dirty(form, task)
+}
+
 function compute_label_suggestions(
 	input: string,
 	labels: ReadonlyArray<LabelItem>,
@@ -104,6 +161,9 @@ const dash_task_form_shared = {
 	is_focus_still_inside_form,
 	compute_pending_new_labels,
 	compute_label_suggestions,
+	apply_add_label,
+	apply_toggle_label,
+	is_inline_form_dirty,
 }
 
 export {
@@ -115,4 +175,4 @@ export {
 	DIALOG_RECURRENCE_CLASS,
 	dash_task_form_shared,
 }
-export type { LabelItem }
+export type { LabelItem, InlineFormValues, TaskFieldSnapshot }


### PR DESCRIPTION
## Summary
- Extracted `DashInlineEditorBaseState.svelte.ts` (core reactive state and `$effect`s) and `DashInlineEditorState.svelte.ts` (event handlers, save logic) from the 1161-line `DashTaskInlineEditor.svelte`
- Created `DashTaskLabelPicker.svelte` shared label picker component — eliminates duplicate label UI between inline editor and create form
- Created `dash-inline-editor-helpers.ts` with pure DOM/timing helper functions
- Refactored `DashTaskInlineEditor.svelte` from 1161 to ~300 lines using the new state class and picker
- Updated `DashCreateTaskForm.svelte` to use `DashTaskLabelPicker`, removing duplicate label section
- Updated `DashCreateFormState.svelte.ts` to delegate `add_label`/`toggle_label_name` to shared pure functions
- Split `is_inline_form_dirty` in `dash-task-form-shared.ts` into 3 focused helpers; added unit tests

## Test plan
- [x] Unit tests added for new pure functions in `dash-task-form-shared.spec.ts`
- [x] `pnpm test:unit --run` — 160 tests pass
- [x] `pnpm test` (E2E) — 35 tests pass locally and in CI
- [x] `pnpm run lint` — clean
- [x] `pnpm run check` — no type errors

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)