### PR TITLE
Introduce Zod for runtime validation #207

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tasks",
 	"private": true,
-	"version": "0.71.0",
+	"version": "0.72.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {
@@ -158,6 +158,7 @@
 	"dependencies": {
 		"fractional-indexing": "^3.2.0",
 		"rrule": "^2.8.1",
-		"svelte-dnd-action": "^0.9.69"
+		"svelte-dnd-action": "^0.9.69",
+		"zod": "^4.3.6"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       svelte-dnd-action:
         specifier: ^0.9.69
         version: 0.9.69(svelte@5.55.3(@typescript-eslint/types@8.58.1))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@better-auth/cli':
         specifier: ~1.4.21

--- a/src/lib/server/automation-cleanup-tasks-body.ts
+++ b/src/lib/server/automation-cleanup-tasks-body.ts
@@ -1,36 +1,19 @@
+import { z } from 'zod'
+
 const MAX_CLEANUP_TITLES = 50
 const MAX_TITLE_CHARS = 500
 
 type ParsedCleanupBody = { ok: true; titles: Array<string> } | { ok: false }
 
-function is_plain_object(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === 'object'
-}
-
-function is_valid_title_string(value: unknown): value is string {
-	return typeof value === 'string' && value.length > 0 && value.length <= MAX_TITLE_CHARS
-}
-
-function is_non_empty_string_array(value: Array<unknown>): value is Array<string> {
-	return value.every(is_valid_title_string)
-}
-
-function validate_raw_array(raw: unknown): raw is Array<unknown> {
-	return Array.isArray(raw) && raw.length > 0 && raw.length <= MAX_CLEANUP_TITLES
-}
-
-function has_titles_key(value: Record<string, unknown>): value is { titles: unknown } {
-	return 'titles' in value
-}
+const cleanup_body_schema = z.object({
+	titles: z.array(z.string().min(1).max(MAX_TITLE_CHARS)).min(1).max(MAX_CLEANUP_TITLES),
+})
 
 function extract_titles(body: unknown): ParsedCleanupBody {
-	if (!is_plain_object(body)) return { ok: false }
-	if (!has_titles_key(body)) return { ok: false }
-	const { titles } = body
-	if (!validate_raw_array(titles)) return { ok: false }
-	if (!is_non_empty_string_array(titles)) return { ok: false }
+	const result = cleanup_body_schema.safeParse(body)
+	if (!result.success) return { ok: false }
 
-	return { ok: true, titles }
+	return { ok: true, titles: result.data.titles }
 }
 
 export { extract_titles, MAX_CLEANUP_TITLES, MAX_TITLE_CHARS }

--- a/src/lib/server/automation-seed-open-tasks-body.ts
+++ b/src/lib/server/automation-seed-open-tasks-body.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 const MAX_SEED_TITLES = 20
 const MAX_TITLE_CHARS = 500
 const ERROR_INVALID = 'invalid body'
@@ -7,58 +9,31 @@ const ERROR_TOO_LONG = 'title too long'
 
 type ParsedSeedBody = { ok: true; titles: Array<string> } | { ok: false; error: string }
 
-function is_plain_record(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === 'object'
-}
+const title_schema = z
+	.string({ error: ERROR_INVALID })
+	.transform((value) => value.trim())
+	.check(
+		z.refine((value) => value.length > 0, { error: ERROR_EMPTY_TITLE }),
+		z.refine((value) => value.length <= MAX_TITLE_CHARS, { error: ERROR_TOO_LONG }),
+	)
 
-function normalize_title_candidate(
-	item: unknown,
-): { ok: true; title: string } | { ok: false; error: string } {
-	if (typeof item !== 'string') return { ok: false, error: ERROR_INVALID }
+const titles_schema = z
+	.array(title_schema, { error: ERROR_INVALID })
+	.min(1, ERROR_EMPTY_TITLE)
+	.max(MAX_SEED_TITLES, ERROR_TOO_MANY)
 
-	const trimmed = item.trim()
-	if (trimmed === '') return { ok: false, error: ERROR_EMPTY_TITLE }
-	if (trimmed.length > MAX_TITLE_CHARS) return { ok: false, error: ERROR_TOO_LONG }
-
-	return { ok: true, title: trimmed }
-}
-
-type TitlePushResult = { kind: 'continue' } | { kind: 'stop'; body: ParsedSeedBody }
-
-function try_push_normalized_title(titles: Array<string>, item: unknown): TitlePushResult {
-	const normalized = normalize_title_candidate(item)
-	if (!normalized.ok) return { kind: 'stop', body: { ok: false, error: normalized.error } }
-
-	titles.push(normalized.title)
-
-	if (titles.length > MAX_SEED_TITLES) {
-		return { kind: 'stop', body: { ok: false, error: ERROR_TOO_MANY } }
-	}
-
-	return { kind: 'continue' }
-}
-
-/* eslint-disable-next-line sonarjs/cognitive-complexity -- linear validation over a short list */
-function collect_titles_from_array(raw_titles: unknown): ParsedSeedBody {
-	if (!Array.isArray(raw_titles)) return { ok: false, error: ERROR_INVALID }
-
-	const titles: Array<string> = []
-
-	for (const item of raw_titles) {
-		const step = try_push_normalized_title(titles, item)
-		if (step.kind === 'stop') return step.body
-	}
-
-	if (titles.length === 0) return { ok: false, error: ERROR_EMPTY_TITLE }
-
-	return { ok: true, titles }
-}
+const seed_body_schema = z.object({ titles: titles_schema }, { error: ERROR_INVALID })
 
 function parse_seed_open_tasks_json(body: unknown): ParsedSeedBody {
-	if (!is_plain_record(body)) return { ok: false, error: ERROR_INVALID }
+	const result = seed_body_schema.safeParse(body)
 
-	/* eslint-disable-next-line dot-notation -- svelte-check: index signature requires bracket access */
-	return collect_titles_from_array(body['titles'])
+	if (!result.success) {
+		const [first_issue] = result.error.issues
+
+		return { ok: false, error: first_issue?.message ?? ERROR_INVALID }
+	}
+
+	return { ok: true, titles: result.data.titles }
 }
 
 export {

--- a/src/lib/server/dash-form-parse.ts
+++ b/src/lib/server/dash-form-parse.ts
@@ -1,4 +1,4 @@
-import { form_utilities } from '$lib/server/utils/form'
+import { z } from 'zod'
 
 interface ParsedCreateTask {
 	title: string
@@ -22,35 +22,115 @@ interface ParsedUpdateTask {
 const ERROR_TASK_ID_REQUIRED = 'タスクIDが必要です'
 const ERROR_TITLE_LINES_REQUIRED = 'タイトルを1行以上入力してください'
 
-function read_label_names_from_form(form_data: FormData): Array<string> {
-	const raw_values = form_data
-		.getAll('labels')
-		.map((entry) => form_utilities.get_string(entry).trim())
+/** Coerce a FormDataEntryValue | null to a trimmed string. */
+function form_string(value: FormDataEntryValue | null): string {
+	return (typeof value === 'string' ? value : '').trim()
+}
+
+/** Return trimmed string or undefined when blank. */
+function optional_string(value: FormDataEntryValue | null): string | undefined {
+	const trimmed = form_string(value)
+
+	return trimmed === '' ? undefined : trimmed
+}
+
+function read_label_names(form_data: FormData): Array<string> {
+	const raw_values = form_data.getAll('labels').map((entry) => form_string(entry))
 
 	return [...new Set(raw_values.filter(Boolean))]
 }
 
-function read_insert_after_id(form_data: FormData): string | undefined {
-	const raw = form_utilities.get_string(form_data.get('insert_after_task_id')).trim()
+const create_schema = z.object({
+	title: z.string().transform((value) => value.trim()),
+	detail: z.string().optional(),
+	due_date: z.string().optional(),
+	recurrence_rule: z.string().optional(),
+	insert_after_task_id: z.string().optional(),
+	insert_at_top: z
+		.string()
+		.optional()
+		.transform((value) => value === '1'),
+})
 
-	return raw === '' ? undefined : raw
-}
-
-function read_create_text_fields(form_data: FormData): {
-	detail: string | undefined
-	due_date: string | undefined
-	recurrence_rule: string | undefined
-} {
-	const detail_raw = form_utilities.get_string(form_data.get('detail')).trim()
-	const due_raw = form_utilities.get_string(form_data.get('due_date')).trim()
-	const recurrence_raw = form_utilities.get_string(form_data.get('recurrence_rule')).trim()
-
+function read_create_raw(form_data: FormData): z.input<typeof create_schema> {
 	return {
-		detail: detail_raw === '' ? undefined : detail_raw,
-		due_date: due_raw === '' ? undefined : due_raw,
-		recurrence_rule: recurrence_raw === '' ? undefined : recurrence_raw,
+		title: form_string(form_data.get('title')),
+		detail: optional_string(form_data.get('detail')),
+		due_date: optional_string(form_data.get('due_date')),
+		recurrence_rule: optional_string(form_data.get('recurrence_rule')),
+		insert_after_task_id: optional_string(form_data.get('insert_after_task_id')),
+		insert_at_top: form_string(form_data.get('insert_at_top')),
 	}
 }
+
+function to_create_task(
+	data: z.output<typeof create_schema>,
+	form_data: FormData,
+): ParsedCreateTask {
+	return {
+		title: data.title,
+		detail: data.detail ?? undefined,
+		due_date: data.due_date ?? undefined,
+		recurrence_rule: data.recurrence_rule ?? undefined,
+		insert_after_task_id: data.insert_after_task_id ?? undefined,
+		insert_at_top: data.insert_at_top,
+		label_names: read_label_names(form_data),
+	}
+}
+
+function parse_create_body(
+	form_data: FormData,
+): { ok: true; data: ParsedCreateTask } | { ok: false; error: string } {
+	const result = create_schema.safeParse(read_create_raw(form_data))
+	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+
+	return { ok: true, data: to_create_task(result.data, form_data) }
+}
+
+const task_id_schema = z.string().min(1, ERROR_TASK_ID_REQUIRED)
+
+const update_task_schema = z.object({
+	task_id: task_id_schema,
+	title: z.string().transform((value) => value.trim()),
+	detail: z.string().optional(),
+	due_date: z.string().optional(),
+	recurrence_rule: z.string().optional(),
+})
+
+function to_update_task(
+	data: z.output<typeof update_task_schema>,
+	form_data: FormData,
+): ParsedUpdateTask {
+	return {
+		task_id: data.task_id,
+		title: data.title,
+		detail: data.detail ?? undefined,
+		due_date: data.due_date ?? undefined,
+		recurrence_rule: data.recurrence_rule ?? undefined,
+		label_names: read_label_names(form_data),
+	}
+}
+
+function parse_update_task_body(
+	form_data: FormData,
+): { ok: true; data: ParsedUpdateTask } | { ok: false; error: string } {
+	const raw = {
+		task_id: form_string(form_data.get('task_id')),
+		title: form_string(form_data.get('title')),
+		detail: optional_string(form_data.get('detail')),
+		due_date: optional_string(form_data.get('due_date')),
+		recurrence_rule: optional_string(form_data.get('recurrence_rule')),
+	}
+	const result = update_task_schema.safeParse(raw)
+	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+
+	return { ok: true, data: to_update_task(result.data, form_data) }
+}
+
+const title_lines_schema = z.object({
+	task_id: task_id_schema,
+	title: z.string(),
+})
 
 function split_title_lines(raw_title: string): Array<string> {
 	return raw_title
@@ -59,68 +139,39 @@ function split_title_lines(raw_title: string): Array<string> {
 		.filter((line) => line.length > 0)
 }
 
-function parse_create_body(
-	form_data: FormData,
-): { ok: true; data: ParsedCreateTask } | { ok: false; error: string } {
-	const title = form_utilities.get_string(form_data.get('title')).trim()
-	const { detail, due_date, recurrence_rule } = read_create_text_fields(form_data)
-	const label_names = read_label_names_from_form(form_data)
-	const insert_after_task_id = read_insert_after_id(form_data)
-	const should_insert_at_top =
-		form_utilities.get_string(form_data.get('insert_at_top')).trim() === '1'
-
-	return {
-		ok: true,
-		data: {
-			title,
-			detail,
-			due_date,
-			recurrence_rule,
-			label_names,
-			insert_after_task_id,
-			insert_at_top: should_insert_at_top,
-		},
-	}
-}
-
-function parse_update_task_body(
-	form_data: FormData,
-): { ok: true; data: ParsedUpdateTask } | { ok: false; error: string } {
-	const task_id = form_utilities.get_string(form_data.get('task_id')).trim()
-	if (!task_id) return { ok: false, error: ERROR_TASK_ID_REQUIRED }
-
-	const title = form_utilities.get_string(form_data.get('title')).trim()
-	const { detail, due_date, recurrence_rule } = read_create_text_fields(form_data)
-	const label_names = read_label_names_from_form(form_data)
-
-	return {
-		ok: true,
-		data: { task_id, title, detail, due_date, recurrence_rule, label_names },
-	}
-}
-
 function parse_update_task_title_body(
 	form_data: FormData,
 ): { ok: true; task_id: string; title_lines: Array<string> } | { ok: false; error: string } {
-	const task_id = form_utilities.get_string(form_data.get('task_id')).trim()
-	if (!task_id) return { ok: false, error: ERROR_TASK_ID_REQUIRED }
+	const raw_title = form_data.get('title')
+	const raw = {
+		task_id: form_string(form_data.get('task_id')),
+		title: typeof raw_title === 'string' ? raw_title : '',
+	}
+	const result = title_lines_schema.safeParse(raw)
+	if (!result.success) return { ok: false, error: result.error.issues[0].message }
 
-	const raw_title = form_utilities.get_string(form_data.get('title'))
-	const title_lines = split_title_lines(raw_title)
-
+	const title_lines = split_title_lines(result.data.title)
 	if (title_lines.length === 0) return { ok: false, error: ERROR_TITLE_LINES_REQUIRED }
 
-	return { ok: true, task_id, title_lines }
+	return { ok: true, task_id: result.data.task_id, title_lines }
 }
+
+const complete_schema = z.object({ task_id: task_id_schema })
 
 function parse_complete_body(
 	form_data: FormData,
 ): { ok: true; task_id: string } | { ok: false; error: string } {
-	const task_id = form_utilities.get_string(form_data.get('task_id')).trim()
-	if (!task_id) return { ok: false, error: ERROR_TASK_ID_REQUIRED }
+	const result = complete_schema.safeParse({ task_id: form_string(form_data.get('task_id')) })
+	if (!result.success) return { ok: false, error: result.error.issues[0].message }
 
-	return { ok: true, task_id }
+	return { ok: true, task_id: result.data.task_id }
 }
+
+const reorder_schema = z.object({
+	task_id: task_id_schema,
+	prev_sort_order: z.string(),
+	next_sort_order: z.string(),
+})
 
 function parse_reorder_body(form_data: FormData):
 	| { ok: true; task_id: string; prev_sort_order: string; next_sort_order: string }
@@ -128,12 +179,15 @@ function parse_reorder_body(form_data: FormData):
 			ok: false
 			error: string
 	  } {
-	const task_id = form_utilities.get_string(form_data.get('task_id')).trim()
-	if (!task_id) return { ok: false, error: ERROR_TASK_ID_REQUIRED }
-	const previous_sort_order = form_utilities.get_string(form_data.get('prev_sort_order')).trim()
-	const next_sort_order = form_utilities.get_string(form_data.get('next_sort_order')).trim()
+	const raw = {
+		task_id: form_string(form_data.get('task_id')),
+		prev_sort_order: form_string(form_data.get('prev_sort_order')),
+		next_sort_order: form_string(form_data.get('next_sort_order')),
+	}
+	const result = reorder_schema.safeParse(raw)
+	if (!result.success) return { ok: false, error: result.error.issues[0].message }
 
-	return { ok: true, task_id, prev_sort_order: previous_sort_order, next_sort_order }
+	return { ok: true, ...result.data }
 }
 
 const dash_form_parse = {

--- a/src/lib/server/dash-form-parse.ts
+++ b/src/lib/server/dash-form-parse.ts
@@ -22,6 +22,14 @@ interface ParsedUpdateTask {
 const ERROR_TASK_ID_REQUIRED = 'タスクIDが必要です'
 const ERROR_TITLE_LINES_REQUIRED = 'タイトルを1行以上入力してください'
 
+const FALLBACK_VALIDATION_ERROR = 'validation error'
+
+function first_issue_message(error: z.ZodError): string {
+	const [first] = error.issues
+
+	return first?.message ?? FALLBACK_VALIDATION_ERROR
+}
+
 /** Coerce a FormDataEntryValue | null to a trimmed string. */
 function form_string(value: FormDataEntryValue | null): string {
 	return (typeof value === 'string' ? value : '').trim()
@@ -82,7 +90,7 @@ function parse_create_body(
 	form_data: FormData,
 ): { ok: true; data: ParsedCreateTask } | { ok: false; error: string } {
 	const result = create_schema.safeParse(read_create_raw(form_data))
-	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+	if (!result.success) return { ok: false, error: first_issue_message(result.error) }
 
 	return { ok: true, data: to_create_task(result.data, form_data) }
 }
@@ -122,7 +130,7 @@ function parse_update_task_body(
 		recurrence_rule: optional_string(form_data.get('recurrence_rule')),
 	}
 	const result = update_task_schema.safeParse(raw)
-	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+	if (!result.success) return { ok: false, error: first_issue_message(result.error) }
 
 	return { ok: true, data: to_update_task(result.data, form_data) }
 }
@@ -148,7 +156,7 @@ function parse_update_task_title_body(
 		title: typeof raw_title === 'string' ? raw_title : '',
 	}
 	const result = title_lines_schema.safeParse(raw)
-	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+	if (!result.success) return { ok: false, error: first_issue_message(result.error) }
 
 	const title_lines = split_title_lines(result.data.title)
 	if (title_lines.length === 0) return { ok: false, error: ERROR_TITLE_LINES_REQUIRED }
@@ -162,7 +170,7 @@ function parse_complete_body(
 	form_data: FormData,
 ): { ok: true; task_id: string } | { ok: false; error: string } {
 	const result = complete_schema.safeParse({ task_id: form_string(form_data.get('task_id')) })
-	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+	if (!result.success) return { ok: false, error: first_issue_message(result.error) }
 
 	return { ok: true, task_id: result.data.task_id }
 }
@@ -185,7 +193,7 @@ function parse_reorder_body(form_data: FormData):
 		next_sort_order: form_string(form_data.get('next_sort_order')),
 	}
 	const result = reorder_schema.safeParse(raw)
-	if (!result.success) return { ok: false, error: result.error.issues[0].message }
+	if (!result.success) return { ok: false, error: first_issue_message(result.error) }
 
 	return { ok: true, ...result.data }
 }

--- a/src/lib/server/utils/form.ts
+++ b/src/lib/server/utils/form.ts
@@ -1,5 +1,0 @@
-export const form_utilities = {
-	get_string: (value: FormDataEntryValue | null): string => {
-		return typeof value === 'string' ? value : ''
-	},
-}


### PR DESCRIPTION
## Summary
- Installed `zod` v4.3.6 as runtime validation library
- Rewrote `dash-form-parse.ts` with 5 Zod schemas replacing manual form parsers
- Rewrote `automation-cleanup-tasks-body.ts` with Zod schema (35 → 18 lines)
- Rewrote `automation-seed-open-tasks-body.ts` with Zod schema (73 → 49 lines)
- Removed `src/lib/server/utils/form.ts` (no longer needed)

## Test plan
- [x] All 209 existing unit tests pass (behavior-preserving refactor)
- [x] All 35 E2E tests pass
- [x] Lint, check, cspell all green

Closes #207